### PR TITLE
adds copy images (local and remote)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,21 @@
-# Copy URL in preview mode
+# Danger. Ugly code ahead 😱
 
-This plugin for [Obsidian](https://obsidian.md/) is a copy URL context menu in preview mode that works like the built in one in edit mode.
+- My fork of https://github.com/NomarCub/obsidian-copy-url-in-preview
+- Adds a right-click → Copy image function
 
-![desktop](https://user-images.githubusercontent.com/5298006/125515738-8fb2143d-6502-46d3-a1b8-57b025211c2f.gif)
+# Installation instructions for testing
 
-The plugin also works on mobile, but was only tested on Android.
+1. Open a Terminal
 
-![android](https://user-images.githubusercontent.com/5298006/125515758-bdf77074-a58c-4a6d-affa-88d031991ab2.gif)
+```shell
+$ git clone --branch copy-images https://github.com/luckman212/obsidian-copy-url-in-preview
+$ cd obsidian-copy-url-in-preview
+$ npm i; npm run build
+```
 
-## Compatibility
+2. Copy the files to your Obsidian plugins dir:
 
-The plugin was tested in Obsidian v0.11.13 and subsequent versions, but probably works with older versions.
+- If you already have **copy-url-in-preview** installed: copy `main.js` to your `<vault>/plugins/copy-url-in-preview/` directory (overwriting the original).
+- If you _don't_: create a new folder in your plugins directory, and put `main.js` and `manifest.json` in it.
 
-## Installation
-
-You can install the plugin via the Community Plugins tab within Obsidian.
-You can also manually copy from releases to your `.obsidian/plugins/copy-url-in-preview` folder.
-
-## Credits
-
-Thank you to the makers of the [Tag Wrangler plugin](https://github.com/pjeby/tag-wrangler), as it was a great starting point for working with context menus in Obsidian.
-
-## Support
-
-If you like this plugin you can support me on PayPal here: [![Paypal](https://img.shields.io/badge/paypal-nomarcub-yellow?style=social&logo=paypal)](https://paypal.me/nomarcub)
+3. (Re)launch Obsidian

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 - My fork of https://github.com/NomarCub/obsidian-copy-url-in-preview
 - Adds a right-click → Copy image function
 
+![image](https://user-images.githubusercontent.com/1992842/126041872-da60dbaa-2bdc-4511-9d05-6ec77157ed46.png)
+
 # Installation instructions for testing
 
 1. Open a Terminal

--- a/main.ts
+++ b/main.ts
@@ -1,72 +1,141 @@
 import {
-	Menu, Plugin, Notice, MenuItem
+  Menu, Plugin, Notice, MenuItem
 } from "obsidian";
 
+const { clipboard, nativeImage } = require('electron');
+const http = require('http');
+const https = require('https');
+
 interface Listener {
-	(this: Document, ev: Event): any;
+  (this: Document, ev: Event): any;
 }
 
 function onElement(
-	el: Document,
-	event: keyof HTMLElementEventMap,
-	selector: string,
-	listener: Listener,
-	options?: { capture?: boolean; }
+  el: Document,
+  event: keyof HTMLElementEventMap,
+  selector: string,
+  listener: Listener,
+  options?: { capture?: boolean; }
 ) {
-	el.on(event, selector, listener, options);
-	return () => el.off(event, selector, listener, options);
+  el.on(event, selector, listener, options);
+  return () => el.off(event, selector, listener, options);
 }
 
 export default class CopyUrlInPreview extends Plugin {
-	onload() {
-		this.register(
-			onElement(
-				document,
-				"contextmenu" as keyof HTMLElementEventMap,
-				"a.external-link",
-				this.onClick.bind(this)
-			)
-		);
-	}
+  onload() {
+    this.register(
+      onElement(
+        document,
+        "contextmenu" as keyof HTMLElementEventMap,
+        "a.external-link",
+        this.onClick.bind(this)
+      )
+    );
+    this.register(
+      onElement(
+        document,
+        "contextmenu" as keyof HTMLElementEventMap,
+        "img",
+        this.onClick.bind(this)
+      )
+    );
+  }
 
-	// Android gives a PointerEvent, a child to MouseEvent.
-	// Positions are not accurate from PointerEvent.
-	// There's also TouchEvent
-	// The event has target, path, toEvent (null on Android) for finding the link
-	onClick(event: MouseEvent) {
-		if (!(event.target instanceof HTMLAnchorElement)) {
-			return;
-		}
+  // Android gives a PointerEvent, a child to MouseEvent.
+  // Positions are not accurate from PointerEvent.
+  // There's also TouchEvent
+  // The event has target, path, toEvent (null on Android) for finding the link
+  onClick(event: MouseEvent) {
+    event.preventDefault();
+    const target = (event.target as any);
+    const elType = <String>target.localName;
 
-		event.preventDefault();
+    const menu = new Menu(this.app);
+    switch (elType) {
+      case 'img':
+        const image = target.currentSrc;
+        var theImage = nativeImage.createEmpty();
+        const thisURL = new URL(image);
+        const thisHREF = thisURL.href;
+        const Proto = <String>thisURL.protocol;
+        switch (Proto) {
+          case 'app:':
+            // console.log('local vault image');
+            var imPath = decodeURIComponent(image);
+            var imPath = imPath.replace(/^app:\/\/local\//, '');
+            var imPath = imPath.replace(/\?.*$/, '');
+            theImage = nativeImage.createFromPath(imPath);
+            break;
+          case 'http:':
+            // console.log('remote HTTP image: %s', thisHREF);
+            http.get(thisHREF, (resp: any) => {
+              resp.setEncoding('base64');
+              var body = "data:" + resp.headers["content-type"] + ";base64,";
+              resp.on('data', (data: any) => { body += data});
+              resp.on('end', () => {
+                theImage = nativeImage.createFromDataURL(body);
+              });
+            }).on('error', (e: Error) => {
+              console.log(`error: ${e.message}`);
+            });
+            break;
+          case 'https:':
+            // console.log('remote HTTPS image: %s', thisHREF);
+            https.get(thisHREF, (resp: any) => {
+              resp.setEncoding('base64');
+              var body = "data:" + resp.headers["content-type"] + ";base64,";
+              resp.on('data', (data: any) => { body += data});
+              resp.on('end', () => {
+                theImage = nativeImage.createFromDataURL(body);
+              });
+            }).on('error', (e: Error) => {
+              console.log(`error: ${e.message}`);
+            });
+            break;
+          default:
+            new Notice("no handler for `" + Proto +"` protocol");
+            return;
+        }
+        menu.addItem((item: MenuItem) =>
+          item.setIcon("link")
+            .setTitle("Copy image")
+            .onClick(() => {
+              clipboard.writeImage(theImage);
+              new Notice("Image copied to your clipboard");
+            })
+        );
+        break;
+      case 'a':
+        let link = target.href;
+        menu.addItem((item: MenuItem) =>
+          item.setIcon("link")
+            .setTitle("Copy url")
+            .onClick(() => {
+              navigator.clipboard.writeText(link);
+              new Notice("Url copied to your clipboard");
+            })
+        );
+        break;
+      default:
+        new Notice("no handler for this element type");
+        return;
+    }
+    menu.register(
+      onElement(
+        document,
+        "keydown" as keyof HTMLElementEventMap,
+        "*",
+        (e: KeyboardEvent) => {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            e.stopPropagation();
+            menu.hide();
+          }
+        }
+      )
+    );
+    menu.showAtPosition({ x: event.pageX, y: event.pageY });
 
-		let link = event.target.href;
-
-		const menu = new Menu(this.app);
-		menu.addItem((item: MenuItem) =>
-			item.setIcon("link")
-				.setTitle("Copy url")
-				.onClick(() => {
-					navigator.clipboard.writeText(link);
-					new Notice("Url copied to your clipboard");
-				})
-		);
-		menu.register(
-			onElement(
-				document,
-				"keydown" as keyof HTMLElementEventMap,
-				"*",
-				(e: KeyboardEvent) => {
-					if (e.key === "Escape") {
-						e.preventDefault();
-						e.stopPropagation();
-						menu.hide();
-					}
-				}
-			)
-		);
-		menu.showAtPosition({ x: event.pageX, y: event.pageY });
-
-		this.app.workspace.trigger("copy-url-in-preview:contextmenu", menu);
-	}
+    this.app.workspace.trigger("copy-url-in-preview:contextmenu", menu);
+  }
 }


### PR DESCRIPTION
### feature add: right click to copy image to clipboard
![image](https://user-images.githubusercontent.com/1992842/126008437-043f4c8b-32fa-42af-b2c8-be506cb33f05.png)

### This is some very hacky code. 😱 I'm sorry.

### Notes

- there MUST be a more efficient way to do this. The image data is already there on the canvas, so going out and re-fetching it from the filesystem, or worse, from a remote webserver is silly
- this most likely won't work in the mobile app, but at least on iOS it isn't needed-you can already long press and copy images
- maybe `contents.copyImageAt(x,y)` -- (see [here](https://www.electronjs.org/docs/latest/api/web-contents/#contentscopyimageatx-y)) is the right solution?
- so far only tested on macOS 11.4, Obsidian 0.12.10

### Related research links:

- [nativeImage.createFromURL(url) · Issue #19031 · electron/electron](https://github.com/electron/electron/issues/19031)
- [Copy images to the clipboard in the Electron app (c11fa4c4) · Commits · Conor Matthews / CA4106 Team 12 · GitLab](https://gitlab.computing.dcu.ie/matthc22/ca4106_team_12/commit/c11fa4c4836d7e9cd8ad956d32da45bf4d154a72)
- [javascript - How to save an image drawn on the canvas in Electron.js - Stack Overflow](https://stackoverflow.com/questions/52692258/how-to-save-an-image-drawn-on-the-canvas-in-electron-js)
- [javascript - Is it possible to copy a canvas image to the clipboard? - Stack Overflow](https://stackoverflow.com/questions/27863617/is-it-possible-to-copy-a-canvas-image-to-the-clipboard)
- [javascript - React - how to copy an image to clipboard? - Stack Overflow](https://stackoverflow.com/questions/59182747/react-how-to-copy-an-image-to-clipboard)
- [Lightcord/clipboard.js at master · Lightcord/Lightcord](https://github.com/Lightcord/Lightcord/blob/master/modules/discord_desktop_core/core/app/discord_native/renderer/clipboard.js)

thank you:
https://stackoverflow.com/questions/17124053/node-js-get-image-from-web-and-encode-with-base64
