### PR TITLE
Fixes: Menu on canvas, open in new tab and external image in LivePreview

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,14 +15,8 @@
         "project": true
     },
     "rules": {
-      "no-unused-vars": "off",
-      "@typescript-eslint/no-unused-vars": ["error", { "args": "none" }],
-      "@typescript-eslint/ban-ts-comment": "off",
-      "no-prototype-builtins": "off",
       "@typescript-eslint/no-unsafe-assignment": "off",
-      "@typescript-eslint/no-unsafe-member-access": "off",
       "@typescript-eslint/no-unsafe-argument": "off",
-      "@typescript-eslint/no-empty-function": "off",
       "@typescript-eslint/no-floating-promises": "off",
       "@typescript-eslint/no-misused-promises": "off"
     } 

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,23 +1,25 @@
 {
-    "root": true,
-    "parser": "@typescript-eslint/parser",
-    "env": { "node": true },
-    "plugins": [
-      "@typescript-eslint"
-    ],
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/eslint-recommended",
-      "plugin:@typescript-eslint/recommended-type-checked"
-    ], 
-    "parserOptions": {
-        "sourceType": "module",
-        "project": true
-    },
-    "rules": {
-      "@typescript-eslint/no-unsafe-assignment": "off",
-      "@typescript-eslint/no-unsafe-argument": "off",
-      "@typescript-eslint/no-floating-promises": "off",
-      "@typescript-eslint/no-misused-promises": "off"
-    } 
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "env": {
+    "node": true
+  },
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended-type-checked"
+  ],
+  "parserOptions": {
+    "sourceType": "module",
+    "project": true
+  },
+  "rules": {
+    "@typescript-eslint/no-unsafe-assignment": "off",
+    "@typescript-eslint/no-unsafe-argument": "off",
+    "@typescript-eslint/no-floating-promises": "off",
+    "@typescript-eslint/no-misused-promises": "off"
   }
+}

--- a/README.md
+++ b/README.md
@@ -52,5 +52,6 @@ If you like this plugin you can sponsor me here on GitHub: [![Sponsor NomarCub](
 - [Copying](https://github.com/NomarCub/obsidian-copy-url-in-preview/pull/2) [images](https://github.com/NomarCub/obsidian-copy-url-in-preview/pull/3) developed by [luckman212](https://github.com/luckman212).
 - [Android image sharing](https://github.com/NomarCub/obsidian-copy-url-in-preview/issues/5) developed by [mnaoumov](https://github.com/mnaoumov).
 - [Open PDF externally](https://github.com/NomarCub/obsidian-copy-url-in-preview/issues/9) feature developed by [mnaoumov](https://github.com/mnaoumov).
+- [Canvas functionality, translations and fixes](https://github.com/NomarCub/obsidian-copy-url-in-preview/pull/40) by [Mara-Li](https://github.com/Mara-Li)
 
 Thank you to the makers of the [Tag Wrangler plugin](https://github.com/pjeby/tag-wrangler), as it was a great starting point for working with context menus in Obsidian.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # Image Context Menus
 
 This plugin provides the following context menus for images in [Obsidian](https://obsidian.md/):
-- Copy image to clipboard
-- Open image in default app
+- Copy to clipboard
+- Open in default app
 - Show in system explorer
 - Reveal file in navigation
 - Open in new tab
   - also available through middle mouse button click
 
 It also has an `Open PDF externally` context menu for PDFs.
+
+Context menus are also added to the canvas.  
+Most features work on mobile, but were only tested on Android. Mobile uses the native image sharing functionality instead of the clipboard, and it downloads online images temporarily so they can be shared.
 
 > This plugin used to be called "Copy Image and URL context menu". It had link URL copying functionality (see [1.5.2](https://github.com/NomarCub/obsidian-copy-url-in-preview/tree/1.5.2) and prior), but that was removed when it was included in Obsidian 1.5.
 
@@ -23,8 +26,6 @@ Copying images:
 Opening PDFs externally:
 
 ![Opening PDFs externally on desktop](https://user-images.githubusercontent.com/5298006/171170626-5a94f5dc-61fc-4661-a9f2-38a0fb0181f5.gif)
-
-All features work on mobile, but were only tested on Android. Mobile uses the native image sharing functionality instead of the clipboard, and it downloads online images temporarily so they can be shared.
 
 ## Installation
 

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -15,7 +15,9 @@ const prod = (process.argv[2] === "production");
 
 let outfile = "main.js";
 if (fs.existsSync('./.devtarget')) {
-	outfile = path.join(fs.readFileSync('./.devtarget', 'utf8').trim(), outfile);
+	const outFolderOverride = fs.readFileSync('./.devtarget', 'utf8').trim().split("\n")
+		.map(line => line.trim()).filter(line => !line.startsWith("#") && !line.startsWith("//"))[0];
+	outfile = path.join(outFolderOverride, outfile);
 	console.log('Temporary output location:', outfile);
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "copy-url-in-preview",
 	"name": "Image Context Menus",
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"minAppVersion": "1.5.7",
 	"description": "Copy, open in default app, show in system explorer, reveal in navigation context menu for images. Also Open PDF externally context menu.",
 	"author": "NomarCub",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "copy-url-in-preview",
 	"name": "Image Context Menus",
-	"version": "1.7.2",
+	"version": "1.8.0",
 	"minAppVersion": "1.5.7",
 	"description": "Copy, open in default app, show in system explorer, reveal in navigation context menu for images. Also Open PDF externally context menu.",
 	"author": "NomarCub",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,23 @@
 				"builtin-modules": "4.0.0",
 				"esbuild": "0.21.4",
 				"eslint": "^8.57.0",
+				"i18next": "^23.11.5",
 				"obsidian": "~1.5.7-1",
 				"obsidian-typings": "^1.1.6",
 				"tslib": "2.6.2",
 				"typescript": "5.4.3"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
+			"integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
+			"dev": true,
+			"dependencies": {
+				"regenerator-runtime": "^0.14.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@codemirror/state": {
@@ -1475,6 +1488,29 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/i18next": {
+			"version": "23.11.5",
+			"resolved": "https://registry.npmjs.org/i18next/-/i18next-23.11.5.tgz",
+			"integrity": "sha512-41pvpVbW9rhZPk5xjCX2TPJi2861LEig/YRhUkY+1FQ2IQPS0bKUDYnEqY8XPPbB48h1uIwLnP9iiEfuSl20CA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://locize.com"
+				},
+				{
+					"type": "individual",
+					"url": "https://locize.com/i18next.html"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+				}
+			],
+			"dependencies": {
+				"@babel/runtime": "^7.23.2"
+			}
+		},
 		"node_modules/ignore": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -1880,6 +1916,12 @@
 					"url": "https://feross.org/support"
 				}
 			]
+		},
+		"node_modules/regenerator-runtime": {
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+			"dev": true
 		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"esbuild": "0.17.3",
 				"eslint": "8.46.0",
 				"obsidian": "~1.5.7-1",
-				"obsidian-typings": "^1.1.3",
+				"obsidian-typings": "^1.1.6",
 				"tslib": "2.4.0",
 				"typescript": "4.7.4"
 			}
@@ -861,12 +861,12 @@
 			}
 		},
 		"node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
 			"dependencies": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -1252,9 +1252,9 @@
 			}
 		},
 		"node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -1643,9 +1643,9 @@
 			}
 		},
 		"node_modules/obsidian-typings": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/obsidian-typings/-/obsidian-typings-1.1.3.tgz",
-			"integrity": "sha512-tEnN5QtGWOdOTmkRBvJzuhiLBTgPaXFBAeASETznM/2vx+Tuz/qpQaoouzPB3p10BEBE9L8RP7rvbWbgkps2gw==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/obsidian-typings/-/obsidian-typings-1.1.6.tgz",
+			"integrity": "sha512-p3iWfvHDJfrwdYKAhb8adlBVOGtGteEy5nE7Jzhb8K5nyrTb5DvOtG+BQGneVM7Ou6UMkZnRoOLPkhJMXLquGw==",
 			"dev": true,
 			"peerDependencies": {
 				"@types/electron": "npm:@ophidian/electron-types",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,24 +10,15 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^20.12.7",
-				"@typescript-eslint/eslint-plugin": "6.2.1",
-				"@typescript-eslint/parser": "6.2.1",
-				"builtin-modules": "3.3.0",
-				"esbuild": "0.17.3",
-				"eslint": "8.46.0",
+				"@typescript-eslint/eslint-plugin": "^7.12.0",
+				"@typescript-eslint/parser": "^7.12.0",
+				"builtin-modules": "4.0.0",
+				"esbuild": "0.21.4",
+				"eslint": "^8.57.0",
 				"obsidian": "~1.5.7-1",
 				"obsidian-typings": "^1.1.6",
-				"tslib": "2.4.0",
-				"typescript": "4.7.4"
-			}
-		},
-		"node_modules/@aashutoshrathi/word-wrap": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-			"integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
+				"tslib": "2.6.2",
+				"typescript": "5.4.3"
 			}
 		},
 		"node_modules/@codemirror/state": {
@@ -49,10 +40,26 @@
 				"w3c-keyname": "^2.2.4"
 			}
 		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.4.tgz",
+			"integrity": "sha512-Zrm+B33R4LWPLjDEVnEqt2+SLTATlru1q/xYKVn8oVTbiRBGmK2VIMoIYGJDGyftnGaC788IuzGFAlb7IQ0Y8A==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.3.tgz",
-			"integrity": "sha512-1Mlz934GvbgdDmt26rTLmf03cAgLg5HyOgJN+ZGCeP3Q9ynYTNMn2/LQxIl7Uy+o4K6Rfi2OuLsr12JQQR8gNg==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.4.tgz",
+			"integrity": "sha512-E7H/yTd8kGQfY4z9t3nRPk/hrhaCajfA3YSQSBrst8B+3uTcgsi8N+ZWYCaeIDsiVs6m65JPCaQN/DxBRclF3A==",
 			"cpu": [
 				"arm"
 			],
@@ -66,9 +73,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.3.tgz",
-			"integrity": "sha512-XvJsYo3dO3Pi4kpalkyMvfQsjxPWHYjoX4MDiB/FUM4YMfWcXa5l4VCwFWVYI1+92yxqjuqrhNg0CZg3gSouyQ==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.4.tgz",
+			"integrity": "sha512-fYFnz+ObClJ3dNiITySBUx+oNalYUT18/AryMxfovLkYWbutXsct3Wz2ZWAcGGppp+RVVX5FiXeLYGi97umisA==",
 			"cpu": [
 				"arm64"
 			],
@@ -82,9 +89,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.3.tgz",
-			"integrity": "sha512-nuV2CmLS07Gqh5/GrZLuqkU9Bm6H6vcCspM+zjp9TdQlxJtIe+qqEXQChmfc7nWdyr/yz3h45Utk1tUn8Cz5+A==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.4.tgz",
+			"integrity": "sha512-mDqmlge3hFbEPbCWxp4fM6hqq7aZfLEHZAKGP9viq9wMUBVQx202aDIfc3l+d2cKhUJM741VrCXEzRFhPDKH3Q==",
 			"cpu": [
 				"x64"
 			],
@@ -98,9 +105,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.3.tgz",
-			"integrity": "sha512-01Hxaaat6m0Xp9AXGM8mjFtqqwDjzlMP0eQq9zll9U85ttVALGCGDuEvra5Feu/NbP5AEP1MaopPwzsTcUq1cw==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.4.tgz",
+			"integrity": "sha512-72eaIrDZDSiWqpmCzVaBD58c8ea8cw/U0fq/PPOTqE3c53D0xVMRt2ooIABZ6/wj99Y+h4ksT/+I+srCDLU9TA==",
 			"cpu": [
 				"arm64"
 			],
@@ -114,9 +121,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.3.tgz",
-			"integrity": "sha512-Eo2gq0Q/er2muf8Z83X21UFoB7EU6/m3GNKvrhACJkjVThd0uA+8RfKpfNhuMCl1bKRfBzKOk6xaYKQZ4lZqvA==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.4.tgz",
+			"integrity": "sha512-uBsuwRMehGmw1JC7Vecu/upOjTsMhgahmDkWhGLWxIgUn2x/Y4tIwUZngsmVb6XyPSTXJYS4YiASKPcm9Zitag==",
 			"cpu": [
 				"x64"
 			],
@@ -130,9 +137,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.3.tgz",
-			"integrity": "sha512-CN62ESxaquP61n1ZjQP/jZte8CE09M6kNn3baos2SeUfdVBkWN5n6vGp2iKyb/bm/x4JQzEvJgRHLGd5F5b81w==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.4.tgz",
+			"integrity": "sha512-8JfuSC6YMSAEIZIWNL3GtdUT5NhUA/CMUCpZdDRolUXNAXEE/Vbpe6qlGLpfThtY5NwXq8Hi4nJy4YfPh+TwAg==",
 			"cpu": [
 				"arm64"
 			],
@@ -146,9 +153,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.3.tgz",
-			"integrity": "sha512-feq+K8TxIznZE+zhdVurF3WNJ/Sa35dQNYbaqM/wsCbWdzXr5lyq+AaTUSER2cUR+SXPnd/EY75EPRjf4s1SLg==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.4.tgz",
+			"integrity": "sha512-8d9y9eQhxv4ef7JmXny7591P/PYsDFc4+STaxC1GBv0tMyCdyWfXu2jBuqRsyhY8uL2HU8uPyscgE2KxCY9imQ==",
 			"cpu": [
 				"x64"
 			],
@@ -162,9 +169,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.3.tgz",
-			"integrity": "sha512-CLP3EgyNuPcg2cshbwkqYy5bbAgK+VhyfMU7oIYyn+x4Y67xb5C5ylxsNUjRmr8BX+MW3YhVNm6Lq6FKtRTWHQ==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.4.tgz",
+			"integrity": "sha512-2rqFFefpYmpMs+FWjkzSgXg5vViocqpq5a1PSRgT0AvSgxoXmGF17qfGAzKedg6wAwyM7UltrKVo9kxaJLMF/g==",
 			"cpu": [
 				"arm"
 			],
@@ -178,9 +185,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.3.tgz",
-			"integrity": "sha512-JHeZXD4auLYBnrKn6JYJ0o5nWJI9PhChA/Nt0G4MvLaMrvXuWnY93R3a7PiXeJQphpL1nYsaMcoV2QtuvRnF/g==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.4.tgz",
+			"integrity": "sha512-/GLD2orjNU50v9PcxNpYZi+y8dJ7e7/LhQukN3S4jNDXCKkyyiyAz9zDw3siZ7Eh1tRcnCHAo/WcqKMzmi4eMQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -194,9 +201,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.3.tgz",
-			"integrity": "sha512-FyXlD2ZjZqTFh0sOQxFDiWG1uQUEOLbEh9gKN/7pFxck5Vw0qjWSDqbn6C10GAa1rXJpwsntHcmLqydY9ST9ZA==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.4.tgz",
+			"integrity": "sha512-pNftBl7m/tFG3t2m/tSjuYeWIffzwAZT9m08+9DPLizxVOsUl8DdFzn9HvJrTQwe3wvJnwTdl92AonY36w/25g==",
 			"cpu": [
 				"ia32"
 			],
@@ -210,9 +217,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.3.tgz",
-			"integrity": "sha512-OrDGMvDBI2g7s04J8dh8/I7eSO+/E7nMDT2Z5IruBfUO/RiigF1OF6xoH33Dn4W/OwAWSUf1s2nXamb28ZklTA==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.4.tgz",
+			"integrity": "sha512-cSD2gzCK5LuVX+hszzXQzlWya6c7hilO71L9h4KHwqI4qeqZ57bAtkgcC2YioXjsbfAv4lPn3qe3b00Zt+jIfQ==",
 			"cpu": [
 				"loong64"
 			],
@@ -226,9 +233,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.3.tgz",
-			"integrity": "sha512-DcnUpXnVCJvmv0TzuLwKBC2nsQHle8EIiAJiJ+PipEVC16wHXaPEKP0EqN8WnBe0TPvMITOUlP2aiL5YMld+CQ==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.4.tgz",
+			"integrity": "sha512-qtzAd3BJh7UdbiXCrg6npWLYU0YpufsV9XlufKhMhYMJGJCdfX/G6+PNd0+v877X1JG5VmjBLUiFB0o8EUSicA==",
 			"cpu": [
 				"mips64el"
 			],
@@ -242,9 +249,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.3.tgz",
-			"integrity": "sha512-BDYf/l1WVhWE+FHAW3FzZPtVlk9QsrwsxGzABmN4g8bTjmhazsId3h127pliDRRu5674k1Y2RWejbpN46N9ZhQ==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.4.tgz",
+			"integrity": "sha512-yB8AYzOTaL0D5+2a4xEy7OVvbcypvDR05MsB/VVPVA7nL4hc5w5Dyd/ddnayStDgJE59fAgNEOdLhBxjfx5+dg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -258,9 +265,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.3.tgz",
-			"integrity": "sha512-WViAxWYMRIi+prTJTyV1wnqd2mS2cPqJlN85oscVhXdb/ZTFJdrpaqm/uDsZPGKHtbg5TuRX/ymKdOSk41YZow==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.4.tgz",
+			"integrity": "sha512-Y5AgOuVzPjQdgU59ramLoqSSiXddu7F3F+LI5hYy/d1UHN7K5oLzYBDZe23QmQJ9PIVUXwOdKJ/jZahPdxzm9w==",
 			"cpu": [
 				"riscv64"
 			],
@@ -274,9 +281,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.3.tgz",
-			"integrity": "sha512-Iw8lkNHUC4oGP1O/KhumcVy77u2s6+KUjieUqzEU3XuWJqZ+AY7uVMrrCbAiwWTkpQHkr00BuXH5RpC6Sb/7Ug==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.4.tgz",
+			"integrity": "sha512-Iqc/l/FFwtt8FoTK9riYv9zQNms7B8u+vAI/rxKuN10HgQIXaPzKZc479lZ0x6+vKVQbu55GdpYpeNWzjOhgbA==",
 			"cpu": [
 				"s390x"
 			],
@@ -290,9 +297,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.3.tgz",
-			"integrity": "sha512-0AGkWQMzeoeAtXQRNB3s4J1/T2XbigM2/Mn2yU1tQSmQRmHIZdkGbVq2A3aDdNslPyhb9/lH0S5GMTZ4xsjBqg==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.4.tgz",
+			"integrity": "sha512-Td9jv782UMAFsuLZINfUpoF5mZIbAj+jv1YVtE58rFtfvoKRiKSkRGQfHTgKamLVT/fO7203bHa3wU122V/Bdg==",
 			"cpu": [
 				"x64"
 			],
@@ -306,9 +313,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.3.tgz",
-			"integrity": "sha512-4+rR/WHOxIVh53UIQIICryjdoKdHsFZFD4zLSonJ9RRw7bhKzVyXbnRPsWSfwybYqw9sB7ots/SYyufL1mBpEg==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.4.tgz",
+			"integrity": "sha512-Awn38oSXxsPMQxaV0Ipb7W/gxZtk5Tx3+W+rAPdZkyEhQ6968r9NvtkjhnhbEgWXYbgV+JEONJ6PcdBS+nlcpA==",
 			"cpu": [
 				"x64"
 			],
@@ -322,9 +329,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.3.tgz",
-			"integrity": "sha512-cVpWnkx9IYg99EjGxa5Gc0XmqumtAwK3aoz7O4Dii2vko+qXbkHoujWA68cqXjhh6TsLaQelfDO4MVnyr+ODeA==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.4.tgz",
+			"integrity": "sha512-IsUmQeCY0aU374R82fxIPu6vkOybWIMc3hVGZ3ChRwL9hA1TwY+tS0lgFWV5+F1+1ssuvvXt3HFqe8roCip8Hg==",
 			"cpu": [
 				"x64"
 			],
@@ -338,9 +345,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.3.tgz",
-			"integrity": "sha512-RxmhKLbTCDAY2xOfrww6ieIZkZF+KBqG7S2Ako2SljKXRFi+0863PspK74QQ7JpmWwncChY25JTJSbVBYGQk2Q==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.4.tgz",
+			"integrity": "sha512-hsKhgZ4teLUaDA6FG/QIu2q0rI6I36tZVfM4DBZv3BG0mkMIdEnMbhc4xwLvLJSS22uWmaVkFkqWgIS0gPIm+A==",
 			"cpu": [
 				"x64"
 			],
@@ -354,9 +361,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.3.tgz",
-			"integrity": "sha512-0r36VeEJ4efwmofxVJRXDjVRP2jTmv877zc+i+Pc7MNsIr38NfsjkQj23AfF7l0WbB+RQ7VUb+LDiqC/KY/M/A==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.4.tgz",
+			"integrity": "sha512-UUfMgMoXPoA/bvGUNfUBFLCh0gt9dxZYIx9W4rfJr7+hKe5jxxHmfOK8YSH4qsHLLN4Ck8JZ+v7Q5fIm1huErg==",
 			"cpu": [
 				"arm64"
 			],
@@ -370,9 +377,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.3.tgz",
-			"integrity": "sha512-wgO6rc7uGStH22nur4aLFcq7Wh86bE9cOFmfTr/yxN3BXvDEdCSXyKkO+U5JIt53eTOgC47v9k/C1bITWL/Teg==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.4.tgz",
+			"integrity": "sha512-yIxbspZb5kGCAHWm8dexALQ9en1IYDfErzjSEq1KzXFniHv019VT3mNtTK7t8qdy4TwT6QYHI9sEZabONHg+aw==",
 			"cpu": [
 				"ia32"
 			],
@@ -386,9 +393,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.3.tgz",
-			"integrity": "sha512-FdVl64OIuiKjgXBjwZaJLKp0eaEckifbhn10dXWhysMJkWblg3OEEGKSIyhiD5RSgAya8WzP3DNkngtIg3Nt7g==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.4.tgz",
+			"integrity": "sha512-sywLRD3UK/qRJt0oBwdpYLBibk7KiRfbswmWRDabuncQYSlf8aLEEUor/oP6KRz8KEG+HoiVLBhPRD5JWjS8Sg==",
 			"cpu": [
 				"x64"
 			],
@@ -417,9 +424,9 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.10.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
-			"integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.1.tgz",
+			"integrity": "sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==",
 			"dev": true,
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -448,27 +455,72 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/@eslint/js": {
-			"version": "8.56.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
-			"integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
+			"version": "8.57.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+			"integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.13",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-			"integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+			"version": "0.11.14",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+			"deprecated": "Use @eslint/config-array instead",
 			"dev": true,
 			"dependencies": {
-				"@humanwhocodes/object-schema": "^2.0.1",
-				"debug": "^4.1.1",
+				"@humanwhocodes/object-schema": "^2.0.2",
+				"debug": "^4.3.1",
 				"minimatch": "^3.0.5"
 			},
 			"engines": {
 				"node": ">=10.10.0"
+			}
+		},
+		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/@humanwhocodes/module-importer": {
@@ -485,9 +537,10 @@
 			}
 		},
 		"node_modules/@humanwhocodes/object-schema": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-			"integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+			"deprecated": "Use @eslint/object-schema instead",
 			"dev": true
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -548,12 +601,6 @@
 			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
 			"dev": true
 		},
-		"node_modules/@types/json-schema": {
-			"version": "7.0.15",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-			"dev": true
-		},
 		"node_modules/@types/node": {
 			"version": "20.12.11",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.11.tgz",
@@ -562,12 +609,6 @@
 			"dependencies": {
 				"undici-types": "~5.26.4"
 			}
-		},
-		"node_modules/@types/semver": {
-			"version": "7.5.6",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
-			"integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
-			"dev": true
 		},
 		"node_modules/@types/tern": {
 			"version": "0.23.9",
@@ -579,34 +620,31 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.2.1.tgz",
-			"integrity": "sha512-iZVM/ALid9kO0+I81pnp1xmYiFyqibAHzrqX4q5YvvVEyJqY+e6rfTXSCsc2jUxGNqJqTfFSSij/NFkZBiBzLw==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.13.0.tgz",
+			"integrity": "sha512-FX1X6AF0w8MdVFLSdqwqN/me2hyhuQg4ykN6ZpVhh1ij/80pTvDKclX1sZB9iqex8SjQfVhwMKs3JtnnMLzG9w==",
 			"dev": true,
 			"dependencies": {
-				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "6.2.1",
-				"@typescript-eslint/type-utils": "6.2.1",
-				"@typescript-eslint/utils": "6.2.1",
-				"@typescript-eslint/visitor-keys": "6.2.1",
-				"debug": "^4.3.4",
+				"@eslint-community/regexpp": "^4.10.0",
+				"@typescript-eslint/scope-manager": "7.13.0",
+				"@typescript-eslint/type-utils": "7.13.0",
+				"@typescript-eslint/utils": "7.13.0",
+				"@typescript-eslint/visitor-keys": "7.13.0",
 				"graphemer": "^1.4.0",
-				"ignore": "^5.2.4",
+				"ignore": "^5.3.1",
 				"natural-compare": "^1.4.0",
-				"natural-compare-lite": "^1.4.0",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
+				"ts-api-utils": "^1.3.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-				"eslint": "^7.0.0 || ^8.0.0"
+				"@typescript-eslint/parser": "^7.0.0",
+				"eslint": "^8.56.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -615,26 +653,26 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.2.1.tgz",
-			"integrity": "sha512-Ld+uL1kYFU8e6btqBFpsHkwQ35rw30IWpdQxgOqOh4NfxSDH6uCkah1ks8R/RgQqI5hHPXMaLy9fbFseIe+dIg==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.13.0.tgz",
+			"integrity": "sha512-EjMfl69KOS9awXXe83iRN7oIEXy9yYdqWfqdrFAYAAr6syP8eLEFI7ZE4939antx2mNgPRW/o1ybm2SFYkbTVA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "6.2.1",
-				"@typescript-eslint/types": "6.2.1",
-				"@typescript-eslint/typescript-estree": "6.2.1",
-				"@typescript-eslint/visitor-keys": "6.2.1",
+				"@typescript-eslint/scope-manager": "7.13.0",
+				"@typescript-eslint/types": "7.13.0",
+				"@typescript-eslint/typescript-estree": "7.13.0",
+				"@typescript-eslint/visitor-keys": "7.13.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
+				"eslint": "^8.56.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -643,16 +681,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.2.1.tgz",
-			"integrity": "sha512-UCqBF9WFqv64xNsIEPfBtenbfodPXsJ3nPAr55mGPkQIkiQvgoWNo+astj9ZUfJfVKiYgAZDMnM6dIpsxUMp3Q==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.0.tgz",
+			"integrity": "sha512-ZrMCe1R6a01T94ilV13egvcnvVJ1pxShkE0+NDjDzH4nvG1wXpwsVI5bZCvE7AEDH1mXEx5tJSVR68bLgG7Dng==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.2.1",
-				"@typescript-eslint/visitor-keys": "6.2.1"
+				"@typescript-eslint/types": "7.13.0",
+				"@typescript-eslint/visitor-keys": "7.13.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -660,25 +698,25 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.2.1.tgz",
-			"integrity": "sha512-fTfCgomBMIgu2Dh2Or3gMYgoNAnQm3RLtRp+jP7A8fY+LJ2+9PNpi5p6QB5C4RSP+U3cjI0vDlI3mspAkpPVbQ==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.13.0.tgz",
+			"integrity": "sha512-xMEtMzxq9eRkZy48XuxlBFzpVMDurUAfDu5Rz16GouAtXm0TaAoTFzqWUFPPuQYXI/CDaH/Bgx/fk/84t/Bc9A==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "6.2.1",
-				"@typescript-eslint/utils": "6.2.1",
+				"@typescript-eslint/typescript-estree": "7.13.0",
+				"@typescript-eslint/utils": "7.13.0",
 				"debug": "^4.3.4",
-				"ts-api-utils": "^1.0.1"
+				"ts-api-utils": "^1.3.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
+				"eslint": "^8.56.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -687,12 +725,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.2.1.tgz",
-			"integrity": "sha512-528bGcoelrpw+sETlyM91k51Arl2ajbNT9L4JwoXE2dvRe1yd8Q64E4OL7vHYw31mlnVsf+BeeLyAZUEQtqahQ==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.0.tgz",
+			"integrity": "sha512-QWuwm9wcGMAuTsxP+qz6LBBd3Uq8I5Nv8xb0mk54jmNoCyDspnMvVsOxI6IsMmway5d1S9Su2+sCKv1st2l6eA==",
 			"dev": true,
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -700,21 +738,22 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.2.1.tgz",
-			"integrity": "sha512-G+UJeQx9AKBHRQBpmvr8T/3K5bJa485eu+4tQBxFq0KoT22+jJyzo1B50JDT9QdC1DEmWQfdKsa8ybiNWYsi0Q==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.0.tgz",
+			"integrity": "sha512-cAvBvUoobaoIcoqox1YatXOnSl3gx92rCZoMRPzMNisDiM12siGilSM4+dJAekuuHTibI2hVC2fYK79iSFvWjw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.2.1",
-				"@typescript-eslint/visitor-keys": "6.2.1",
+				"@typescript-eslint/types": "7.13.0",
+				"@typescript-eslint/visitor-keys": "7.13.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
+				"minimatch": "^9.0.4",
+				"semver": "^7.6.0",
+				"ts-api-utils": "^1.3.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -727,46 +766,49 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.2.1.tgz",
-			"integrity": "sha512-eBIXQeupYmxVB6S7x+B9SdBeB6qIdXKjgQBge2J+Ouv8h9Cxm5dHf/gfAZA6dkMaag+03HdbVInuXMmqFB/lKQ==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.0.tgz",
+			"integrity": "sha512-jceD8RgdKORVnB4Y6BqasfIkFhl4pajB1wVxrF4akxD2QPM8GNYjgGwEzYS+437ewlqqrg7Dw+6dhdpjMpeBFQ==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
-				"@types/json-schema": "^7.0.12",
-				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.2.1",
-				"@typescript-eslint/types": "6.2.1",
-				"@typescript-eslint/typescript-estree": "6.2.1",
-				"semver": "^7.5.4"
+				"@typescript-eslint/scope-manager": "7.13.0",
+				"@typescript-eslint/types": "7.13.0",
+				"@typescript-eslint/typescript-estree": "7.13.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
+				"eslint": "^8.56.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.2.1.tgz",
-			"integrity": "sha512-iTN6w3k2JEZ7cyVdZJTVJx2Lv7t6zFA8DCrJEHD2mwfc16AEvvBWVhbFh34XyG2NORCd0viIgQY1+u7kPI0WpA==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.0.tgz",
+			"integrity": "sha512-nxn+dozQx+MK61nn/JP+M4eCkHDSxSLDpgE3WcQo0+fkjEolnaB5jswvIKC4K56By8MMgIho7f1PVxERHEo8rw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.2.1",
-				"eslint-visitor-keys": "^3.4.1"
+				"@typescript-eslint/types": "7.13.0",
+				"eslint-visitor-keys": "^3.4.3"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			}
+		},
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+			"dev": true
 		},
 		"node_modules/acorn": {
 			"version": "8.11.3",
@@ -851,13 +893,12 @@
 			"dev": true
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 			"dev": true,
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/braces": {
@@ -873,12 +914,12 @@
 			}
 		},
 		"node_modules/builtin-modules": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
-			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-4.0.0.tgz",
+			"integrity": "sha512-p1n8zyCkt1BVrKNFymOHjcDSAl7oq/gUvfgULv2EblgpPVQlQr9yHnWjg9IJ2MhfwPqiYqMMrr01OY7yQoK2yA==",
 			"dev": true,
 			"engines": {
-				"node": ">=6"
+				"node": ">=18.20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -948,9 +989,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+			"integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
 			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
@@ -995,9 +1036,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.3.tgz",
-			"integrity": "sha512-9n3AsBRe6sIyOc6kmoXg2ypCLgf3eZSraWFRpnkto+svt8cZNuKTkb1bhQcitBcvIqjNiK7K0J3KPmwGSfkA8g==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.4.tgz",
+			"integrity": "sha512-sFMcNNrj+Q0ZDolrp5pDhH0nRPN9hLIM3fRPwgbLYJeSHHgnXSnbV3xYgSVuOeLWH9c73VwmEverVzupIv5xuA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -1007,28 +1048,29 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"@esbuild/android-arm": "0.17.3",
-				"@esbuild/android-arm64": "0.17.3",
-				"@esbuild/android-x64": "0.17.3",
-				"@esbuild/darwin-arm64": "0.17.3",
-				"@esbuild/darwin-x64": "0.17.3",
-				"@esbuild/freebsd-arm64": "0.17.3",
-				"@esbuild/freebsd-x64": "0.17.3",
-				"@esbuild/linux-arm": "0.17.3",
-				"@esbuild/linux-arm64": "0.17.3",
-				"@esbuild/linux-ia32": "0.17.3",
-				"@esbuild/linux-loong64": "0.17.3",
-				"@esbuild/linux-mips64el": "0.17.3",
-				"@esbuild/linux-ppc64": "0.17.3",
-				"@esbuild/linux-riscv64": "0.17.3",
-				"@esbuild/linux-s390x": "0.17.3",
-				"@esbuild/linux-x64": "0.17.3",
-				"@esbuild/netbsd-x64": "0.17.3",
-				"@esbuild/openbsd-x64": "0.17.3",
-				"@esbuild/sunos-x64": "0.17.3",
-				"@esbuild/win32-arm64": "0.17.3",
-				"@esbuild/win32-ia32": "0.17.3",
-				"@esbuild/win32-x64": "0.17.3"
+				"@esbuild/aix-ppc64": "0.21.4",
+				"@esbuild/android-arm": "0.21.4",
+				"@esbuild/android-arm64": "0.21.4",
+				"@esbuild/android-x64": "0.21.4",
+				"@esbuild/darwin-arm64": "0.21.4",
+				"@esbuild/darwin-x64": "0.21.4",
+				"@esbuild/freebsd-arm64": "0.21.4",
+				"@esbuild/freebsd-x64": "0.21.4",
+				"@esbuild/linux-arm": "0.21.4",
+				"@esbuild/linux-arm64": "0.21.4",
+				"@esbuild/linux-ia32": "0.21.4",
+				"@esbuild/linux-loong64": "0.21.4",
+				"@esbuild/linux-mips64el": "0.21.4",
+				"@esbuild/linux-ppc64": "0.21.4",
+				"@esbuild/linux-riscv64": "0.21.4",
+				"@esbuild/linux-s390x": "0.21.4",
+				"@esbuild/linux-x64": "0.21.4",
+				"@esbuild/netbsd-x64": "0.21.4",
+				"@esbuild/openbsd-x64": "0.21.4",
+				"@esbuild/sunos-x64": "0.21.4",
+				"@esbuild/win32-arm64": "0.21.4",
+				"@esbuild/win32-ia32": "0.21.4",
+				"@esbuild/win32-x64": "0.21.4"
 			}
 		},
 		"node_modules/escape-string-regexp": {
@@ -1044,18 +1086,19 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.46.0.tgz",
-			"integrity": "sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==",
+			"version": "8.57.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+			"integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
-				"@eslint/eslintrc": "^2.1.1",
-				"@eslint/js": "^8.46.0",
-				"@humanwhocodes/config-array": "^0.11.10",
+				"@eslint/eslintrc": "^2.1.4",
+				"@eslint/js": "8.57.0",
+				"@humanwhocodes/config-array": "^0.11.14",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
+				"@ungap/structured-clone": "^1.2.0",
 				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -1063,7 +1106,7 @@
 				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
 				"eslint-scope": "^7.2.2",
-				"eslint-visitor-keys": "^3.4.2",
+				"eslint-visitor-keys": "^3.4.3",
 				"espree": "^9.6.1",
 				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
@@ -1123,6 +1166,28 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/eslint/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/espree": {
@@ -1231,9 +1296,9 @@
 			"dev": true
 		},
 		"node_modules/fastq": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
-			"integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+			"integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
 			"dev": true,
 			"dependencies": {
 				"reusify": "^1.0.4"
@@ -1294,9 +1359,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.2.9",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-			"integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
 			"dev": true
 		},
 		"node_modules/fs.realpath": {
@@ -1309,6 +1374,7 @@
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
 			"dev": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
@@ -1335,6 +1401,28 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/glob/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/glob/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/globals": {
@@ -1388,9 +1476,9 @@
 			}
 		},
 		"node_modules/ignore": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
-			"integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
 			"dev": true,
 			"engines": {
 				"node": ">= 4"
@@ -1425,6 +1513,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
 			"dev": true,
 			"dependencies": {
 				"once": "^1.3.0",
@@ -1555,18 +1644,6 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
-		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1577,12 +1654,12 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+			"integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
 			"dev": true,
 			"dependencies": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			},
 			"engines": {
@@ -1590,15 +1667,18 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "9.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+			"integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
 			"dev": true,
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/moment": {
@@ -1620,12 +1700,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-			"dev": true
-		},
-		"node_modules/natural-compare-lite": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
 			"dev": true
 		},
 		"node_modules/obsidian": {
@@ -1663,17 +1737,17 @@
 			}
 		},
 		"node_modules/optionator": {
-			"version": "0.9.3",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
-			"integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
 			"dev": true,
 			"dependencies": {
-				"@aashutoshrathi/word-wrap": "^1.2.3",
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
 				"levn": "^0.4.1",
 				"prelude-ls": "^1.2.1",
-				"type-check": "^0.4.0"
+				"type-check": "^0.4.0",
+				"word-wrap": "^1.2.5"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
@@ -1830,6 +1904,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
 			"dev": true,
 			"dependencies": {
 				"glob": "^7.1.3"
@@ -1865,13 +1940,10 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -1971,21 +2043,21 @@
 			}
 		},
 		"node_modules/ts-api-utils": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
-			"integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+			"integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
 			"dev": true,
 			"engines": {
-				"node": ">=16.13.0"
+				"node": ">=16"
 			},
 			"peerDependencies": {
 				"typescript": ">=4.2.0"
 			}
 		},
 		"node_modules/tslib": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
 			"dev": true
 		},
 		"node_modules/type-check": {
@@ -2013,16 +2085,16 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
+			"integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/undici-types": {
@@ -2062,16 +2134,19 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/word-wrap": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true
-		},
-		"node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
 		"node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "copy-url-in-preview",
-	"version": "1.7.2",
+	"version": "1.8.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "copy-url-in-preview",
-			"version": "1.7.2",
+			"version": "1.8.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^20.12.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "copy-url-in-preview",
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "copy-url-in-preview",
-			"version": "1.7.1",
+			"version": "1.7.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^20.12.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "copy-url-in-preview",
-	"version": "1.7.2",
+	"version": "1.8.0",
 	"description": "Copy Image, Copy URL and Open PDF externally context menu in reading view (formerly preview mode) for Obsidian (https://obsidian.md)",
 	"main": "main.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "copy-url-in-preview",
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"description": "Copy Image, Copy URL and Open PDF externally context menu in reading view (formerly preview mode) for Obsidian (https://obsidian.md)",
 	"main": "main.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"esbuild": "0.17.3",
 		"eslint": "8.46.0",
 		"obsidian": "~1.5.7-1",
-		"obsidian-typings": "^1.1.3",
+		"obsidian-typings": "^1.1.6",
 		"tslib": "2.4.0",
 		"typescript": "4.7.4"
 	}

--- a/package.json
+++ b/package.json
@@ -9,19 +9,18 @@
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},
-	"keywords": [],
-	"author": "",
+	"author": "NomarCub",
 	"license": "MIT",
 	"devDependencies": {
 		"@types/node": "^20.12.7",
-		"@typescript-eslint/eslint-plugin": "6.2.1",
-		"@typescript-eslint/parser": "6.2.1",
-		"builtin-modules": "3.3.0",
-		"esbuild": "0.17.3",
-		"eslint": "8.46.0",
+		"@typescript-eslint/eslint-plugin": "^7.12.0",
+		"@typescript-eslint/parser": "^7.12.0",
+		"builtin-modules": "4.0.0",
+		"esbuild": "0.21.4",
+		"eslint": "^8.57.0",
 		"obsidian": "~1.5.7-1",
 		"obsidian-typings": "^1.1.6",
-		"tslib": "2.4.0",
-		"typescript": "4.7.4"
+		"tslib": "2.6.2",
+		"typescript": "5.4.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"builtin-modules": "4.0.0",
 		"esbuild": "0.21.4",
 		"eslint": "^8.57.0",
+		"i18next": "^23.11.5",
 		"obsidian": "~1.5.7-1",
 		"obsidian-typings": "^1.1.6",
 		"tslib": "2.6.2",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,4 @@
-import { App, FileSystemAdapter, TFile } from "obsidian";
+import { App, CanvasNode, FileSystemAdapter, TFile } from "obsidian";
 
 const loadImageBlobTimeout = 5_000;
 
@@ -8,6 +8,13 @@ export interface ElectronWindow extends Window {
 
 export interface FileSystemAdapterWithInternalApi extends FileSystemAdapter {
 	open(path: string): Promise<void>
+}
+
+export interface CanvasNodeWithUrl extends CanvasNode {
+	unknownData: {
+		url: string
+		type: string
+	}
 }
 
 export interface Listener {
@@ -106,3 +113,4 @@ export function openImageFromMouseEvent(event: MouseEvent, app: App) {
 		app.workspace.getLeaf(true).openFile(imageAsTFile, { active: true });
 	}
 }
+

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -142,17 +142,15 @@ export function setMenuItem(item: MenuItem, type: "copy-to-clipboard", imageSour
 export function setMenuItem(item: MenuItem, type: menuType): MenuItem;
 export function setMenuItem(item: MenuItem, type: menuType, imageSource?: string | Promise<ArrayBuffer>): MenuItem {
 	const types: Record<menuType, { icon: string, title: string, section: "info" | "system" | "open" }> = {
-		"copy-to-clipboard": { section: "info", icon: "image-file", title: i18next.t("interface.label-copy") },
-		"open-in-new-tab": { section: "open", icon: "file-plus", title: i18next.t("interface.menu.open-in-new-tab") },
-		"open-in-default-app": { section: "system", icon: "arrow-up-right", title: i18next.t("plugins.open-with-default-app.action-open-file") },
+		"copy-to-clipboard": { section: "info", icon: "image-file", title: "interface.label-copy" },
+		"open-in-new-tab": { section: "open", icon: "file-plus", title: "interface.menu.open-in-new-tab" },
+		"open-in-default-app": { section: "system", icon: "arrow-up-right", title: "plugins.open-with-default-app.action-open-file" },
 		"show-in-explorer": {
 			section: "system", icon: "arrow-up-right",
-			title: Platform.isMacOS
-				? i18next.t("plugins.open-with-default-app.action-show-in-folder-mac")
-				: i18next.t("plugins.open-with-default-app.action-show-in-folder")
+			title: "plugins.open-with-default-app.action-show-in-folder" + (Platform.isMacOS ? "-mac" : "")
 		},
-		"reveal-in-navigation": { section: "system", icon: "folder", title: i18next.t("plugins.file-explorer.action-reveal-file") },
-		"open-pdf": { section: "system", icon: "arrow-up-right", title: i18next.t("plugins.open-with-default-app.action-open-file") },
+		"reveal-in-navigation": { section: "system", icon: "folder", title: "plugins.file-explorer.action-reveal-file" },
+		"open-pdf": { section: "system", icon: "arrow-up-right", title: "plugins.open-with-default-app.action-open-file" },
 	}
 	if (type === "copy-to-clipboard" && imageSource) {
 		item.onClick(async () => {
@@ -161,7 +159,7 @@ export function setMenuItem(item: MenuItem, type: menuType, imageSource?: string
 	}
 	return item
 		.setIcon(types[type].icon)
-		.setTitle(types[type].title)
+		.setTitle(i18next.t(types[type].title))
 		.setSection(types[type].section);
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -109,7 +109,11 @@ export function getRelativePath(url: URL, app: App): string | undefined {
 	}
 }
 
-export function openImageFromMouseEvent(event: MouseEvent, app: App) {
+export function openTfileInNewTab(app: App, tfile: TFile) {
+	app.workspace.getLeaf(true).openFile(tfile, { active: true });
+}
+
+export function openImageInNewTabFromEvent(app: App, event: MouseEvent) {
 	const image = imageElementFromMouseEvent(event);
 	if (!image) return;
 
@@ -121,7 +125,7 @@ export function openImageFromMouseEvent(event: MouseEvent, app: App) {
 		: app.vault.getAbstractFileByPath(link);
 
 	if (imageAsTFile && imageAsTFile instanceof TFile) {
-		app.workspace.getLeaf(true).openFile(imageAsTFile, { active: true });
+		openTfileInNewTab(app, imageAsTFile);
 	}
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -96,9 +96,11 @@ export function openImageFromMouseEvent(event: MouseEvent, app: App) {
 	if (!image) return;
 
 	const activeFile = app.workspace.getActiveFile();
+	const link = getRelativePath(new URL(image.src), app);
+	if (!link) return;
 	const imageAsTFile = activeFile
-		? app.metadataCache.getFirstLinkpathDest(image.alt, activeFile.path)
-		: app.vault.getAbstractFileByPath(image.alt);
+		? app.metadataCache.getFirstLinkpathDest(link, activeFile.path)
+		: app.vault.getAbstractFileByPath(link);
 
 	if (imageAsTFile && imageAsTFile instanceof TFile) {
 		app.workspace.getLeaf(true).openFile(imageAsTFile, { active: true });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -137,10 +137,10 @@ type menuType =
 	"reveal-in-navigation" |
 	"open-pdf";
 
-export function setMenuVisuals(item: MenuItem, type: "copy-to-clipboard", imageSource: Promise<ArrayBuffer>): MenuItem;
-export function setMenuVisuals(item: MenuItem, type: "copy-to-clipboard", imageSource: string): MenuItem;
-export function setMenuVisuals(item: MenuItem, type: menuType): MenuItem;
-export function setMenuVisuals(item: MenuItem, type: menuType, imageSource?: string | Promise<ArrayBuffer>): MenuItem {
+export function setMenuItem(item: MenuItem, type: "copy-to-clipboard", imageSource: Promise<ArrayBuffer>): MenuItem;
+export function setMenuItem(item: MenuItem, type: "copy-to-clipboard", imageSource: string): MenuItem;
+export function setMenuItem(item: MenuItem, type: menuType): MenuItem;
+export function setMenuItem(item: MenuItem, type: menuType, imageSource?: string | Promise<ArrayBuffer>): MenuItem {
 	const types: Record<menuType, { icon: string, title: string, section: "info" | "system" | "open" }> = {
 		"copy-to-clipboard": { section: "info", icon: "image-file", title: i18next.t("interface.label-copy") },
 		"open-in-new-tab": { section: "open", icon: "file-plus", title: i18next.t("interface.menu.open-in-new-tab") },

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -129,8 +129,6 @@ export function registerEscapeButton(menu: Menu) {
 		}));
 }
 
-const Translate = i18next.t.bind(i18next) as unknown as (key: string) => string;
-
 type menuType =
 	"open-in-new-tab" |
 	"copy-to-clipboard" |
@@ -144,17 +142,17 @@ export function setMenuVisuals(item: MenuItem, type: "copy-to-clipboard", imageS
 export function setMenuVisuals(item: MenuItem, type: menuType): MenuItem;
 export function setMenuVisuals(item: MenuItem, type: menuType, imageSource?: string | Promise<ArrayBuffer>): MenuItem {
 	const types: Record<menuType, { icon: string, title: string, section: "info" | "system" | "open" }> = {
-		"copy-to-clipboard": { section: "info", icon: "image-file", title: Translate("interface.label-copy") },
-		"open-in-new-tab": { section: "open", icon: "file-plus", title: Translate("interface.menu.open-in-new-tab") },
-		"open-in-default-app": { section: "system", icon: "arrow-up-right", title: Translate("plugins.open-with-default-app.action-open-file") },
+		"copy-to-clipboard": { section: "info", icon: "image-file", title: i18next.t("interface.label-copy") },
+		"open-in-new-tab": { section: "open", icon: "file-plus", title: i18next.t("interface.menu.open-in-new-tab") },
+		"open-in-default-app": { section: "system", icon: "arrow-up-right", title: i18next.t("plugins.open-with-default-app.action-open-file") },
 		"show-in-explorer": {
 			section: "system", icon: "arrow-up-right",
 			title: Platform.isMacOS
-				? Translate("plugins.open-with-default-app.action-show-in-folder-mac")
-				: Translate("plugins.open-with-default-app.action-show-in-folder")
+				? i18next.t("plugins.open-with-default-app.action-show-in-folder-mac")
+				: i18next.t("plugins.open-with-default-app.action-show-in-folder")
 		},
-		"reveal-in-navigation": { section: "system", icon: "folder", title: Translate("plugins.file-explorer.action-reveal-file") },
-		"open-pdf": { section: "system", icon: "arrow-up-right", title: Translate("plugins.open-with-default-app.action-open-file") },
+		"reveal-in-navigation": { section: "system", icon: "folder", title: i18next.t("plugins.file-explorer.action-reveal-file") },
+		"open-pdf": { section: "system", icon: "arrow-up-right", title: i18next.t("plugins.open-with-default-app.action-open-file") },
 	}
 	if (type === "copy-to-clipboard" && imageSource) {
 		item.onClick(async () => {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -141,7 +141,10 @@ type menuType =
 	"reveal-in-navigation" |
 	"open-pdf";
 
-export function setMenuVisuals(item: MenuItem, type: menuType): MenuItem {
+export function setMenuVisuals(item: MenuItem, type: "copy-to-clipboard", imageSource: Promise<ArrayBuffer>): MenuItem;
+export function setMenuVisuals(item: MenuItem, type: "copy-to-clipboard", imageSource: string): MenuItem;
+export function setMenuVisuals(item: MenuItem, type: menuType): MenuItem;
+export function setMenuVisuals(item: MenuItem, type: menuType, imageSource?: string | Promise<ArrayBuffer>): MenuItem {
 	const types: Record<menuType, { icon: string, title: string }> = {
 		"copy-to-clipboard": { icon: "image-file", title: "Copy image to clipboard" },
 		"open-in-new-tab": { icon: "arrow-up-right", title: "Open in new tab" },
@@ -149,6 +152,11 @@ export function setMenuVisuals(item: MenuItem, type: menuType): MenuItem {
 		"show-in-explorer": { icon: "arrow-up-right", title: Platform.isMacOS ? "Reveal in Finder" : "Show in system explorer" },
 		"reveal-in-navigation": { icon: "folder", title: "Reveal file in navigation" },
 		"open-pdf": { icon: "pdf-file", title: "Open PDF externally" },
+	}
+	if (type === "copy-to-clipboard" && imageSource) {
+		item.onClick(async () => {
+			await copyImageToClipboard(typeof imageSource === "string" ? imageSource : await imageSource);
+		});
 	}
 	return item.setIcon(types[type].icon).setTitle(types[type].title);
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -141,19 +141,19 @@ export function setMenuVisuals(item: MenuItem, type: "copy-to-clipboard", imageS
 export function setMenuVisuals(item: MenuItem, type: "copy-to-clipboard", imageSource: string): MenuItem;
 export function setMenuVisuals(item: MenuItem, type: menuType): MenuItem;
 export function setMenuVisuals(item: MenuItem, type: menuType, imageSource?: string | Promise<ArrayBuffer>): MenuItem {
-	const types: Record<menuType, { icon: string, title: string }> = {
-		"copy-to-clipboard": { icon: "image-file", title: Translate("interface.label-copy") },
-		"open-in-new-tab": { icon: "file-plus", title: Translate("interface.menu.open-in-new-tab") },
-		"open-in-default-app": { icon: "arrow-up-right", title: Translate("plugins.open-with-default-app.action-open-file") },
-		"show-in-explorer": { icon: "arrow-up-right", title: Platform.isMacOS ? Translate("plugins.open-with-default-app.action-show-in-folder-mac") : Translate("plugins.open-with-default-app.action-show-in-folder") },
-		"reveal-in-navigation": { icon: "folder", title: Translate("plugins.file-explorer.action-reveal-file") },
-		"open-pdf": { icon: "pdf-file", title: Translate("plugins.open-with-default-app.action-open-file") },
+	const types: Record<menuType, { icon: string, title: string, section: "info" | "system" | "open" }> = {
+		"copy-to-clipboard": { icon: "image-file", title: Translate("interface.label-copy"), section: "info" },
+		"open-in-new-tab": { icon: "file-plus", title: Translate("interface.menu.open-in-new-tab"), section: "open" },
+		"open-in-default-app": { icon: "arrow-up-right", title: Translate("plugins.open-with-default-app.action-open-file"), section: "system" },
+		"show-in-explorer": { icon: "arrow-up-right", title: Platform.isMacOS ? Translate("plugins.open-with-default-app.action-show-in-folder-mac") : Translate("plugins.open-with-default-app.action-show-in-folder"), section: "system" },
+		"reveal-in-navigation": { icon: "folder", title: Translate("plugins.file-explorer.action-reveal-file"), section: "system" },
+		"open-pdf": { icon: "pdf-file", title: Translate("plugins.open-with-default-app.action-open-file"), section: "system" },
 	}
 	if (type === "copy-to-clipboard" && imageSource) {
 		item.onClick(async () => {
 			await copyImageToClipboard(typeof imageSource === "string" ? imageSource : await imageSource);
 		});
 	}
-	return item.setIcon(types[type].icon).setTitle(types[type].title);
+	return item.setIcon(types[type].icon).setTitle(types[type].title).setSection(types[type].section);
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,4 @@
-import { App, FileSystemAdapter, normalizePath, TFile, View } from "obsidian";
+import { App, FileSystemAdapter, TFile } from "obsidian";
 
 const loadImageBlobTimeout = 5_000;
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -10,12 +10,8 @@ export const timeouts = {
 };
 
 export function withTimeout<T>(ms: number, promise: Promise<T>): Promise<T> {
-	const timeout = new Promise((_resolve, reject) => {
-		const id = setTimeout(() => {
-			clearTimeout(id);
-			reject(`timed out after ${ms} ms`)
-		}, ms)
-	}) as unknown as Promise<T>;
+	const timeout = new Promise<never>((_, reject) =>
+		setTimeout(() => reject(`timed out after ${ms} ms`), ms));
 	return Promise.race([
 		promise,
 		timeout

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -103,22 +103,6 @@ export function openImageFromMouseEvent(event: MouseEvent, app: App) {
 	const image = imageElementFromMouseEvent(event);
 	if (!image) return;
 
-	/* const leaf = app.workspace.getLeaf(true);
-    app.workspace.setActiveLeaf(leaf, { focus: true });
-
-    const relativePath = getRelativePath(new URL(image.currentSrc), app);
-    if (relativePath) {
-        const titleContainerEl = (leaf.view as View & { titleContainerEl: Node }).titleContainerEl;
-        titleContainerEl.empty();
-        titleContainerEl.createEl("div", { text: relativePath })
-    }
-
-    const contentEl = (leaf.view as View & { contentEl: Node }).contentEl;
-    contentEl.empty();
-    const div = contentEl.createEl("div", {});
-    const img = div.appendChild(document.createElement("img"));
-    img.src = image.currentSrc; */
-
 	const activeFile = app.workspace.getActiveFile();
 	const imageAsTFile = activeFile
 		? app.metadataCache.getFirstLinkpathDest(image.alt, activeFile.path)

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -3,11 +3,11 @@ import { App, FileSystemAdapter, TFile } from "obsidian";
 const loadImageBlobTimeout = 5_000;
 
 export interface ElectronWindow extends Window {
-	WEBVIEW_SERVER_URL: string;
+	WEBVIEW_SERVER_URL: string
 }
 
 export interface FileSystemAdapterWithInternalApi extends FileSystemAdapter {
-	open(path: string): Promise<void>;
+	open(path: string): Promise<void>
 }
 
 export interface Listener {
@@ -18,71 +18,63 @@ export function withTimeout<T>(ms: number, promise: Promise<T>): Promise<T> {
 	const timeout = new Promise((_resolve, reject) => {
 		const id = setTimeout(() => {
 			clearTimeout(id);
-			reject(`timed out after ${ms} ms`);
-		}, ms);
+			reject(`timed out after ${ms} ms`)
+		}, ms)
 	}) as unknown as Promise<T>;
-	return Promise.race([promise, timeout]);
+	return Promise.race([
+		promise,
+		timeout
+	]);
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
 // option?: https://www.npmjs.com/package/html-to-image
 export async function loadImageBlob(imgSrc: string): Promise<Blob> {
-	const loadImageBlobCore = () =>
-		new Promise<Blob>((resolve, reject) => {
-			const image = new Image();
-			image.crossOrigin = "anonymous";
-			image.onload = () => {
-				const canvas = document.createElement("canvas");
-				canvas.width = image.width;
-				canvas.height = image.height;
-				const ctx = canvas.getContext("2d")!;
-				ctx.drawImage(image, 0, 0);
-				canvas.toBlob((blob: Blob) => {
-					resolve(blob);
-				});
-			};
-			image.onerror = async () => {
-				try {
-					await fetch(image.src, { mode: "no-cors" });
+	const loadImageBlobCore = () => new Promise<Blob>((resolve, reject) => {
+		const image = new Image();
+		image.crossOrigin = "anonymous";
+		image.onload = () => {
+			const canvas = document.createElement("canvas");
+			canvas.width = image.width;
+			canvas.height = image.height;
+			const ctx = canvas.getContext("2d")!;
+			ctx.drawImage(image, 0, 0);
+			canvas.toBlob((blob: Blob) => {
+				resolve(blob);
+			});
+		};
+		image.onerror = async () => {
+			try {
+				await fetch(image.src, { "mode": "no-cors" });
 
-					// console.log("possible CORS violation, falling back to allOrigins proxy");
-					// https://github.com/gnuns/allOrigins
-					const blob = await loadImageBlob(
-						`https://api.allorigins.win/raw?url=${encodeURIComponent(
-							imgSrc
-						)}`
-					);
-					resolve(blob);
-				} catch {
-					reject();
-				}
-			};
-			image.src = imgSrc;
-		});
-	return withTimeout(loadImageBlobTimeout, loadImageBlobCore());
+				// console.log("possible CORS violation, falling back to allOrigins proxy");
+				// https://github.com/gnuns/allOrigins
+				const blob = await loadImageBlob(`https://api.allorigins.win/raw?url=${encodeURIComponent(imgSrc)}`);
+				resolve(blob);
+			} catch {
+				reject();
+			}
+		}
+		image.src = imgSrc;
+	});
+	return withTimeout(loadImageBlobTimeout, loadImageBlobCore())
 }
 
 export function onElement(
-	el: Document,
-	event: keyof HTMLElementEventMap,
-	selector: string,
+	el: Document, event: keyof HTMLElementEventMap, selector: string,
 	listener: Listener,
-	options?: { capture?: boolean }
+	options?: { capture?: boolean; }
 ) {
 	el.on(event, selector, listener, options);
 	return () => el.off(event, selector, listener, options);
 }
 
-export function imageElementFromMouseEvent(
-	event: MouseEvent
-): HTMLImageElement | undefined {
+export function imageElementFromMouseEvent(event: MouseEvent): HTMLImageElement | undefined {
 	const imageElement = event.target;
 	if (!(imageElement instanceof HTMLImageElement)) {
-		console.error(
-			"imageElement is supposed to be a HTMLImageElement. imageElement:"
-		);
-		console.error(imageElement);
-	} else {
+		console.error("imageElement is supposed to be a HTMLImageElement. imageElement:", imageElement);
+	}
+	else {
 		return imageElement;
 	}
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -136,18 +136,18 @@ type menuType =
 	"show-in-explorer" |
 	"reveal-in-navigation" |
 	"open-pdf";
-
+const Translate = i18next.t.bind(i18next) as unknown as (key: string) => string;
 export function setMenuVisuals(item: MenuItem, type: "copy-to-clipboard", imageSource: Promise<ArrayBuffer>): MenuItem;
 export function setMenuVisuals(item: MenuItem, type: "copy-to-clipboard", imageSource: string): MenuItem;
 export function setMenuVisuals(item: MenuItem, type: menuType): MenuItem;
 export function setMenuVisuals(item: MenuItem, type: menuType, imageSource?: string | Promise<ArrayBuffer>): MenuItem {
 	const types: Record<menuType, { icon: string, title: string }> = {
-		"copy-to-clipboard": { icon: "image-file", title: "Copy image to clipboard" },
-		"open-in-new-tab": { icon: "arrow-up-right", title: "Open in new tab" },
-		"open-in-default-app": { icon: "arrow-up-right", title: "Open in default app" },
-		"show-in-explorer": { icon: "arrow-up-right", title: Platform.isMacOS ? "Reveal in Finder" : "Show in system explorer" },
-		"reveal-in-navigation": { icon: "folder", title: "Reveal file in navigation" },
-		"open-pdf": { icon: "pdf-file", title: "Open PDF externally" },
+		"copy-to-clipboard": { icon: "image-file", title: Translate("interface.label-copy") },
+		"open-in-new-tab": { icon: "file-plus", title: Translate("interface.menu.open-in-new-tab") },
+		"open-in-default-app": { icon: "arrow-up-right", title: Translate("plugins.open-with-default-app.action-open-file") },
+		"show-in-explorer": { icon: "arrow-up-right", title: Platform.isMacOS ? Translate("plugins.open-with-default-app.action-show-in-folder-mac") : Translate("plugins.open-with-default-app.action-show-in-folder") },
+		"reveal-in-navigation": { icon: "folder", title: Translate("plugins.file-explorer.action-reveal-file") },
+		"open-pdf": { icon: "pdf-file", title: Translate("plugins.open-with-default-app.action-open-file") },
 	}
 	if (type === "copy-to-clipboard" && imageSource) {
 		item.onClick(async () => {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,102 +1,109 @@
-import { App, FileSystemAdapter, View } from "obsidian";
+import { App, FileSystemAdapter, normalizePath, TFile, View } from "obsidian";
 
 const loadImageBlobTimeout = 5_000;
 
 export interface ElectronWindow extends Window {
-    WEBVIEW_SERVER_URL: string
+	WEBVIEW_SERVER_URL: string;
 }
 
 export interface FileSystemAdapterWithInternalApi extends FileSystemAdapter {
-    open(path: string): Promise<void>
+	open(path: string): Promise<void>;
 }
 
 export interface Listener {
-    (this: Document, ev: Event): unknown;
+	(this: Document, ev: Event): unknown;
 }
 
 export function withTimeout<T>(ms: number, promise: Promise<T>): Promise<T> {
-    const timeout = new Promise((_resolve, reject) => {
-        const id = setTimeout(() => {
-            clearTimeout(id);
-            reject(`timed out after ${ms} ms`)
-        }, ms)
-    }) as unknown as Promise<T>;
-    return Promise.race([
-        promise,
-        timeout
-    ]);
+	const timeout = new Promise((_resolve, reject) => {
+		const id = setTimeout(() => {
+			clearTimeout(id);
+			reject(`timed out after ${ms} ms`);
+		}, ms);
+	}) as unknown as Promise<T>;
+	return Promise.race([promise, timeout]);
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
 // option?: https://www.npmjs.com/package/html-to-image
 export async function loadImageBlob(imgSrc: string): Promise<Blob> {
-    const loadImageBlobCore = () => new Promise<Blob>((resolve, reject) => {
-        const image = new Image();
-        image.crossOrigin = "anonymous";
-        image.onload = () => {
-            const canvas = document.createElement("canvas");
-            canvas.width = image.width;
-            canvas.height = image.height;
-            const ctx = canvas.getContext("2d")!;
-            ctx.drawImage(image, 0, 0);
-            canvas.toBlob((blob: Blob) => {
-                resolve(blob);
-            });
-        };
-        image.onerror = async () => {
-            try {
-                await fetch(image.src, { "mode": "no-cors" });
+	const loadImageBlobCore = () =>
+		new Promise<Blob>((resolve, reject) => {
+			const image = new Image();
+			image.crossOrigin = "anonymous";
+			image.onload = () => {
+				const canvas = document.createElement("canvas");
+				canvas.width = image.width;
+				canvas.height = image.height;
+				const ctx = canvas.getContext("2d")!;
+				ctx.drawImage(image, 0, 0);
+				canvas.toBlob((blob: Blob) => {
+					resolve(blob);
+				});
+			};
+			image.onerror = async () => {
+				try {
+					await fetch(image.src, { mode: "no-cors" });
 
-                // console.log("possible CORS violation, falling back to allOrigins proxy");
-                // https://github.com/gnuns/allOrigins
-                const blob = await loadImageBlob(`https://api.allorigins.win/raw?url=${encodeURIComponent(imgSrc)}`);
-                resolve(blob);
-            } catch {
-                reject();
-            }
-        }
-        image.src = imgSrc;
-    });
-    return withTimeout(loadImageBlobTimeout, loadImageBlobCore())
+					// console.log("possible CORS violation, falling back to allOrigins proxy");
+					// https://github.com/gnuns/allOrigins
+					const blob = await loadImageBlob(
+						`https://api.allorigins.win/raw?url=${encodeURIComponent(
+							imgSrc
+						)}`
+					);
+					resolve(blob);
+				} catch {
+					reject();
+				}
+			};
+			image.src = imgSrc;
+		});
+	return withTimeout(loadImageBlobTimeout, loadImageBlobCore());
 }
 
 export function onElement(
-    el: Document, event: keyof HTMLElementEventMap, selector: string,
-    listener: Listener,
-    options?: { capture?: boolean; }
+	el: Document,
+	event: keyof HTMLElementEventMap,
+	selector: string,
+	listener: Listener,
+	options?: { capture?: boolean }
 ) {
-    el.on(event, selector, listener, options);
-    return () => el.off(event, selector, listener, options);
+	el.on(event, selector, listener, options);
+	return () => el.off(event, selector, listener, options);
 }
 
-export function imageElementFromMouseEvent(event: MouseEvent): HTMLImageElement | undefined {
-    const imageElement = event.target;
-    if (!(imageElement instanceof HTMLImageElement)) {
-        console.error("imageElement is supposed to be a HTMLImageElement. imageElement:");
-        console.error(imageElement);
-    }
-    else {
-        return imageElement;
-    }
+export function imageElementFromMouseEvent(
+	event: MouseEvent
+): HTMLImageElement | undefined {
+	const imageElement = event.target;
+	if (!(imageElement instanceof HTMLImageElement)) {
+		console.error(
+			"imageElement is supposed to be a HTMLImageElement. imageElement:"
+		);
+		console.error(imageElement);
+	} else {
+		return imageElement;
+	}
 }
 
 export function getRelativePath(url: URL, app: App): string | undefined {
-    // getResourcePath("") also works for root path
-    const baseFileUrl = app.vault.adapter.getFilePath("");
-    const basePath = baseFileUrl.replace("file://", "");
+	// getResourcePath("") also works for root path
+	const baseFileUrl = app.vault.adapter.getFilePath("");
+	const basePath = baseFileUrl.replace("file://", "");
 
-    const urlPathName: string = url.pathname;
-    if (urlPathName.startsWith(basePath)) {
-      const relativePath = urlPathName.substring(basePath.length + 1);
-      return decodeURI(relativePath);
-    }
+	const urlPathName: string = url.pathname;
+	if (urlPathName.startsWith(basePath)) {
+		const relativePath = urlPathName.substring(basePath.length + 1);
+		return decodeURI(relativePath);
+	}
 }
 
 export function openImageFromMouseEvent(event: MouseEvent, app: App) {
-    const image = imageElementFromMouseEvent(event);
-    if (!image) return;
+	const image = imageElementFromMouseEvent(event);
+	if (!image) return;
 
-    const leaf = app.workspace.getLeaf(true);
+	/* const leaf = app.workspace.getLeaf(true);
     app.workspace.setActiveLeaf(leaf, { focus: true });
 
     const relativePath = getRelativePath(new URL(image.currentSrc), app);
@@ -110,5 +117,14 @@ export function openImageFromMouseEvent(event: MouseEvent, app: App) {
     contentEl.empty();
     const div = contentEl.createEl("div", {});
     const img = div.appendChild(document.createElement("img"));
-    img.src = image.currentSrc;
+    img.src = image.currentSrc; */
+
+	const activeFile = app.workspace.getActiveFile();
+	const imageAsTFile = activeFile
+		? app.metadataCache.getFirstLinkpathDest(image.alt, activeFile.path)
+		: app.vault.getAbstractFileByPath(image.alt);
+
+	if (imageAsTFile && imageAsTFile instanceof TFile) {
+		app.workspace.getLeaf(true).openFile(imageAsTFile, { active: true });
+	}
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -147,7 +147,7 @@ export function setMenuVisuals(item: MenuItem, type: menuType, imageSource?: str
 		"open-in-default-app": { icon: "arrow-up-right", title: Translate("plugins.open-with-default-app.action-open-file"), section: "system" },
 		"show-in-explorer": { icon: "arrow-up-right", title: Platform.isMacOS ? Translate("plugins.open-with-default-app.action-show-in-folder-mac") : Translate("plugins.open-with-default-app.action-show-in-folder"), section: "system" },
 		"reveal-in-navigation": { icon: "folder", title: Translate("plugins.file-explorer.action-reveal-file"), section: "system" },
-		"open-pdf": { icon: "pdf-file", title: Translate("plugins.open-with-default-app.action-open-file"), section: "system" },
+		"open-pdf": { icon: "arrow-up-right", title: Translate("plugins.open-with-default-app.action-open-file"), section: "system" },
 	}
 	if (type === "copy-to-clipboard" && imageSource) {
 		item.onClick(async () => {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -129,6 +129,8 @@ export function registerEscapeButton(menu: Menu) {
 		}));
 }
 
+const Translate = i18next.t.bind(i18next) as unknown as (key: string) => string;
+
 type menuType =
 	"open-in-new-tab" |
 	"copy-to-clipboard" |
@@ -136,24 +138,32 @@ type menuType =
 	"show-in-explorer" |
 	"reveal-in-navigation" |
 	"open-pdf";
-const Translate = i18next.t.bind(i18next) as unknown as (key: string) => string;
+
 export function setMenuVisuals(item: MenuItem, type: "copy-to-clipboard", imageSource: Promise<ArrayBuffer>): MenuItem;
 export function setMenuVisuals(item: MenuItem, type: "copy-to-clipboard", imageSource: string): MenuItem;
 export function setMenuVisuals(item: MenuItem, type: menuType): MenuItem;
 export function setMenuVisuals(item: MenuItem, type: menuType, imageSource?: string | Promise<ArrayBuffer>): MenuItem {
 	const types: Record<menuType, { icon: string, title: string, section: "info" | "system" | "open" }> = {
-		"copy-to-clipboard": { icon: "image-file", title: Translate("interface.label-copy"), section: "info" },
-		"open-in-new-tab": { icon: "file-plus", title: Translate("interface.menu.open-in-new-tab"), section: "open" },
-		"open-in-default-app": { icon: "arrow-up-right", title: Translate("plugins.open-with-default-app.action-open-file"), section: "system" },
-		"show-in-explorer": { icon: "arrow-up-right", title: Platform.isMacOS ? Translate("plugins.open-with-default-app.action-show-in-folder-mac") : Translate("plugins.open-with-default-app.action-show-in-folder"), section: "system" },
-		"reveal-in-navigation": { icon: "folder", title: Translate("plugins.file-explorer.action-reveal-file"), section: "system" },
-		"open-pdf": { icon: "arrow-up-right", title: Translate("plugins.open-with-default-app.action-open-file"), section: "system" },
+		"copy-to-clipboard": { section: "info", icon: "image-file", title: Translate("interface.label-copy") },
+		"open-in-new-tab": { section: "open", icon: "file-plus", title: Translate("interface.menu.open-in-new-tab") },
+		"open-in-default-app": { section: "system", icon: "arrow-up-right", title: Translate("plugins.open-with-default-app.action-open-file") },
+		"show-in-explorer": {
+			section: "system", icon: "arrow-up-right",
+			title: Platform.isMacOS
+				? Translate("plugins.open-with-default-app.action-show-in-folder-mac")
+				: Translate("plugins.open-with-default-app.action-show-in-folder")
+		},
+		"reveal-in-navigation": { section: "system", icon: "folder", title: Translate("plugins.file-explorer.action-reveal-file") },
+		"open-pdf": { section: "system", icon: "arrow-up-right", title: Translate("plugins.open-with-default-app.action-open-file") },
 	}
 	if (type === "copy-to-clipboard" && imageSource) {
 		item.onClick(async () => {
 			await copyImageToClipboard(typeof imageSource === "string" ? imageSource : await imageSource);
 		});
 	}
-	return item.setIcon(types[type].icon).setTitle(types[type].title).setSection(types[type].section);
+	return item
+		.setIcon(types[type].icon)
+		.setTitle(types[type].title)
+		.setSection(types[type].section);
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -87,9 +87,7 @@ export default class CopyUrlInPreview extends Plugin {
 				menu.addItem((item) => item
 					.setIcon("image-file")
 					.setTitle(strings.menuItems.copyImageToClipboard)
-					.onClick(async () => {
-						await this.copyImageToClipboard(url);
-					}));
+					.onClick(async () => { await this.copyImageToClipboard(url); }));
 			}
 		}));
 	}
@@ -201,7 +199,7 @@ export default class CopyUrlInPreview extends Plugin {
 		} else {
 			pdfFile = this.app.workspace.getActiveFile()!;
 		}
-		//hide the menu on canvas
+		// hide the menu on canvas
 		if (isInCanvas) {
 			const canvasCardMenu = activeDocument.querySelector<HTMLElement>(".menu");
 			if (canvasCardMenu) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,10 +107,6 @@ export default class CopyUrlInPreview extends Plugin {
 		);
 	}
 
-	onunload(): void {
-		console.log("unloading plugin");
-	}
-
 	registerDocument(document: Document) {
 		this.register(
 			onElement(

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,7 @@ export default class CopyUrlInPreview extends Plugin {
 	openPdfMenu?: Menu;
 	preventReopenPdfMenu: boolean;
 	lastHoveredLinkTarget: string;
+	otherMenu?: HTMLElement;
 
 	settings: CopyUrlInPreviewSettings;
 	async loadSettings() {
@@ -163,12 +164,15 @@ export default class CopyUrlInPreview extends Plugin {
 		if (!this.settings.pdfMenu || this.openPdfMenu || this.preventReopenPdfMenu) {
 			return;
 		}
-		if (!this.settings.enableDefaultOnCanvas && this.app.workspace.getActiveFile()?.extension === "canvas") {
+		const isInCanvas = this.app.workspace.getActiveFile()?.extension === "canvas"
+		if (!this.settings.enableDefaultOnCanvas && isInCanvas) {
 			return;
 		}
 
 		const rect = el.getBoundingClientRect();
-		if (rect.left + OPEN_PDF_MENU_BORDER_SIZE < event.x
+		
+		if (!isInCanvas 
+			&& rect.left + OPEN_PDF_MENU_BORDER_SIZE < event.x
 			&& event.x < rect.right - OPEN_PDF_MENU_BORDER_SIZE
 			&& rect.top + OPEN_PDF_MENU_BORDER_SIZE < event.y
 			&& event.y < rect.bottom - OPEN_PDF_MENU_BORDER_SIZE) {
@@ -197,7 +201,14 @@ export default class CopyUrlInPreview extends Plugin {
 		} else {
 			pdfFile = this.app.workspace.getActiveFile()!;
 		}
-
+		//hide the menu on canvas
+		if (isInCanvas) {
+			const otherMenu = activeDocument.querySelector<HTMLElement>(".menu");
+			if (otherMenu) {
+				otherMenu.style.display = "none";
+				this.otherMenu = otherMenu;
+			}
+		}
 		const menu = new Menu();
 		this.registerEscapeButton(menu);
 		menu.onHide(() => this.openPdfMenu = undefined);
@@ -236,6 +247,9 @@ export default class CopyUrlInPreview extends Plugin {
 	hideOpenPdfMenu() {
 		if (this.openPdfMenu) {
 			this.openPdfMenu.hide();
+		}
+		if (this.otherMenu) {
+			this.otherMenu.style.display = "";
 		}
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ export default class CopyUrlInPreview extends Plugin {
 		// register the image menu for canvas
 		this.registerEvent(this.app.workspace.on("file-menu", (menu, file, source) => {
 			if (source === "canvas-menu" && file instanceof TFile && (file.extension.match(imageFileRegex) || file.extension === "pdf")
-			)  {
+			) {
 				menu.addItem(item => setMenuItem(item, "open-in-new-tab")
 					.setSection("open")
 					.onClick(() => { openTfileInNewTab(this.app, file); })
@@ -175,7 +175,7 @@ export default class CopyUrlInPreview extends Plugin {
 		const menu = new Menu();
 		registerEscapeButton(menu);
 		menu.onHide(() => this.openPdfMenu = undefined);
-		
+
 		menu.addItem(item => setMenuItem(item, "open-pdf")
 			.onClick(async () => {
 				this.preventReopenPdfMenu = true;
@@ -282,30 +282,39 @@ export default class CopyUrlInPreview extends Plugin {
 
 		event.preventDefault();
 		const menu = new Menu();
-		menu.addItem(item => setMenuItem(item, "copy-to-clipboard", image));
 		const relativePath = getRelativePath(url, this.app);
-		if (protocol === "app:" && Platform.isDesktop && relativePath) {
+		menu.addSections(["open", "copy", "system"]);
+		if (protocol === "app:" && relativePath) {
+			//open in new tab is natif to Obsidian, so no need to check if it's mobile supported :)
 			menu.addItem(item => setMenuItem(item, "open-in-new-tab")
+				.setSection("open")
 				.onClick(() => { openImageInNewTabFromEvent(this.app, event); })
 			);
-			menu.addItem(item => setMenuItem(item, "open-in-default-app")
-				.onClick(() => this.app.openWithDefaultApp(relativePath))
-			);
-			menu.addItem(item => setMenuItem(item, "show-in-explorer")
-				.onClick(() => { this.app.showInFolder(relativePath); })
-			);
-			menu.addItem(item => setMenuItem(item, "reveal-in-navigation")
-				.onClick(() => {
-					const file = this.app.vault.getFileByPath(relativePath);
-					if (!file) {
-						console.warn(`getFileByPath returned null for ${relativePath}`);
-						return;
-					}
-					this.app.internalPlugins.getEnabledPluginById("file-explorer")?.revealInFolder(file);
-				})
-			);
-		}
+			if (Platform.isDesktop) {
 
+				menu.addItem(item => setMenuItem(item, "open-in-default-app")
+					.setSection("system")
+					.onClick(() => this.app.openWithDefaultApp(relativePath))
+				);
+				menu.addItem(item => setMenuItem(item, "show-in-explorer")
+					.setSection("system")
+					.onClick(() => { this.app.showInFolder(relativePath); })
+				);
+				menu.addItem(item => setMenuItem(item, "reveal-in-navigation")
+					.setSection("system")
+					.onClick(() => {
+						const file = this.app.vault.getFileByPath(relativePath);
+						if (!file) {
+							console.warn(`getFileByPath returned null for ${relativePath}`);
+							return;
+						}
+						this.app.internalPlugins.getEnabledPluginById("file-explorer")?.revealInFolder(file);
+					})
+				);
+			}
+		}
+		menu.addItem(item => setMenuItem(item, "copy-to-clipboard", image)
+			.setSection("copy"));
 		registerEscapeButton(menu);
 
 		menu.showAtPosition({ x: event.pageX, y: event.pageY });

--- a/src/main.ts
+++ b/src/main.ts
@@ -162,7 +162,10 @@ export default class CopyUrlInPreview extends Plugin {
 		if (!this.settings.pdfMenu || this.openPdfMenu || this.preventReopenPdfMenu) {
 			return;
 		}
-		if (this.app.workspace.getActiveFile()?.extension === "canvas") return;
+		if (!this.settings.enableDefaultOnCanvas && this.app.workspace.getActiveFile()?.extension === "canvas") {
+			return;
+		}
+
 		const rect = el.getBoundingClientRect();
 		if (rect.left + OPEN_PDF_MENU_BORDER_SIZE < event.x
 			&& event.x < rect.right - OPEN_PDF_MENU_BORDER_SIZE
@@ -292,8 +295,11 @@ export default class CopyUrlInPreview extends Plugin {
 	onImageContextMenu(event: MouseEvent) {
 		const imageElement = imageElementFromMouseEvent(event);
 		if (!imageElement) return;
-		// check if the image is in canvas
-		if (this.app.workspace.getActiveFile()?.extension === "canvas") return;
+		// check if the image is on a canvas
+		if (!this.settings.enableDefaultOnCanvas && this.app.workspace.getActiveFile()?.extension === "canvas") {
+			return;
+		}
+
 		const image = imageElement.currentSrc;
 		const url = new URL(image);
 		const protocol = url.protocol;

--- a/src/main.ts
+++ b/src/main.ts
@@ -176,6 +176,9 @@ export default class CopyUrlInPreview extends Plugin {
 		}
 
 		const pdfEmbed = el.closest(".pdf-embed");
+		// check if the pdf is on a canvas
+		// the context menu crash on loaded pdfs
+		if (pdfEmbed?.className === "canvas-node-content pdf-embed is-loaded") { return; }
 		let pdfFile: TFile;
 		if (pdfEmbed) {
 			let pdfLink: string;
@@ -185,10 +188,11 @@ export default class CopyUrlInPreview extends Plugin {
 			else {
 				pdfLink = pdfEmbed.getAttr("src") ?? this.lastHoveredLinkTarget;
 			}
-
+			
 			pdfLink = pdfLink?.replace(/#page=\d+$/, '');
 
 			const currentNotePath = this.app.workspace.getActiveFile()!.path;
+			
 			pdfFile = this.app.metadataCache.getFirstLinkpathDest(pdfLink!, currentNotePath)!;
 		} else {
 			pdfFile = this.app.workspace.getActiveFile()!;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,7 @@
 import { Menu, Plugin, Notice, Platform, TFile, MarkdownView } from "obsidian";
 import {
 	loadImageBlob, onElement, openImageInNewTabFromEvent, imageElementFromMouseEvent,
-	getRelativePath, timeouts, copyImageToClipboard, openTfileInNewTab, setMenuVisuals,
-	registerEscapeButton
+	getRelativePath, timeouts, openTfileInNewTab, setMenuVisuals as setMenuItem, registerEscapeButton
 } from "./helpers";
 import { CanvasNodeWithUrl, FileSystemAdapterWithInternalApi, ElectronWindow } from "types";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -36,27 +35,24 @@ export default class CopyUrlInPreview extends Plugin {
 		this.registerEvent(this.app.workspace.on("file-menu", (menu, file, source) => {
 			if (source === "canvas-menu" && file instanceof TFile
 				&& file.extension.match(imageFileRegex)) {
-				menu.addItem(item => setMenuVisuals(item, "open-in-new-tab")
+				menu.addItem(item => setMenuItem(item, "open-in-new-tab")
 					.setSection("system")
 					.onClick(() => { openTfileInNewTab(this.app, file); })
 				);
-				menu.addItem(item => setMenuVisuals(item, "copy-to-clipboard")
-					.setSection("system")
-					.onClick(async () => { await copyImageToClipboard(await this.app.vault.readBinary(file)); }));
+				menu.addItem(item => setMenuItem(item, "copy-to-clipboard", this.app.vault.readBinary(file))
+					.setSection("system"))
 			}
 		}));
 		this.registerEvent(this.app.workspace.on("canvas:node-menu", (menu, node: CanvasNodeWithUrl) => {
 			if (node.unknownData?.type === "link") {
 				const url = node.unknownData?.url;
-				menu.addItem(item => setMenuVisuals(item, "copy-to-clipboard")
-					.setSection("canvas")
-					.onClick(async () => { await copyImageToClipboard(url); }));
+				menu.addItem(item => setMenuItem(item, "copy-to-clipboard", url)
+					.setSection("canvas"));
 			}
 		}));
 		this.registerEvent(this.app.workspace.on("url-menu", (menu, url) => {
 			if (url.match(imageFileRegex)) {
-				menu.addItem(item => setMenuVisuals(item, "copy-to-clipboard")
-					.onClick(async () => { await copyImageToClipboard(url); }));
+				menu.addItem(item => setMenuItem(item, "copy-to-clipboard", url));
 			}
 		}));
 	}
@@ -180,7 +176,7 @@ export default class CopyUrlInPreview extends Plugin {
 		const menu = new Menu();
 		registerEscapeButton(menu);
 		menu.onHide(() => this.openPdfMenu = undefined);
-		menu.addItem(item => setMenuVisuals(item, "open-pdf")
+		menu.addItem(item => setMenuItem(item, "open-pdf")
 			.onClick(async () => {
 				this.preventReopenPdfMenu = true;
 				setTimeout(() => { this.preventReopenPdfMenu = false; }, timeouts.openPdfMenu);
@@ -286,21 +282,19 @@ export default class CopyUrlInPreview extends Plugin {
 
 		event.preventDefault();
 		const menu = new Menu();
-		menu.addItem(item => setMenuVisuals(item, "copy-to-clipboard")
-			.onClick(async () => { await copyImageToClipboard(image); })
-		);
+		menu.addItem(item => setMenuItem(item, "copy-to-clipboard", image));
 		const relativePath = getRelativePath(url, this.app);
 		if (protocol === "app:" && Platform.isDesktop && relativePath) {
-			menu.addItem(item => setMenuVisuals(item, "open-in-new-tab")
+			menu.addItem(item => setMenuItem(item, "open-in-new-tab")
 				.onClick(() => { openImageInNewTabFromEvent(this.app, event); })
 			);
-			menu.addItem(item => setMenuVisuals(item, "open-in-default-app")
+			menu.addItem(item => setMenuItem(item, "open-in-default-app")
 				.onClick(() => this.app.openWithDefaultApp(relativePath))
 			);
-			menu.addItem(item => setMenuVisuals(item, "show-in-explorer")
+			menu.addItem(item => setMenuItem(item, "show-in-explorer")
 				.onClick(() => { this.app.showInFolder(relativePath); })
 			);
-			menu.addItem(item => setMenuVisuals(item, "reveal-in-navigation")
+			menu.addItem(item => setMenuItem(item, "reveal-in-navigation")
 				.onClick(() => {
 					const file = this.app.vault.getFileByPath(relativePath);
 					if (!file) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,6 @@ export default class CopyUrlInPreview extends Plugin {
 	preventReopenPdfMenu: boolean;
 	lastHoveredLinkTarget: string;
 	canvasCardMenu?: HTMLElement;
-
 	settings: CopyUrlInPreviewSettings;
 	async loadSettings() {
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
@@ -33,14 +32,14 @@ export default class CopyUrlInPreview extends Plugin {
 		});
 		// register the image menu for canvas
 		this.registerEvent(this.app.workspace.on("file-menu", (menu, file, source) => {
-			if (source === "canvas-menu" && file instanceof TFile
-				&& file.extension.match(imageFileRegex)) {
+			if (source === "canvas-menu" && file instanceof TFile && (file.extension.match(imageFileRegex) || file.extension === "pdf")
+			)  {
 				menu.addItem(item => setMenuItem(item, "open-in-new-tab")
-					.setSection("system")
+					.setSection("open")
 					.onClick(() => { openTfileInNewTab(this.app, file); })
 				);
 				menu.addItem(item => setMenuItem(item, "copy-to-clipboard", this.app.vault.readBinary(file))
-					.setSection("system"))
+					.setSection("info"))
 			}
 		}));
 		this.registerEvent(this.app.workspace.on("canvas:node-menu", (menu, node: CanvasNodeWithUrl) => {
@@ -176,6 +175,7 @@ export default class CopyUrlInPreview extends Plugin {
 		const menu = new Menu();
 		registerEscapeButton(menu);
 		menu.onHide(() => this.openPdfMenu = undefined);
+		
 		menu.addItem(item => setMenuItem(item, "open-pdf")
 			.onClick(async () => {
 				this.preventReopenPdfMenu = true;
@@ -266,7 +266,7 @@ export default class CopyUrlInPreview extends Plugin {
 		if (!imageElement) return;
 		// check if the image is on a canvas
 		if (!this.settings.enableDefaultOnCanvas && this.app.workspace.getActiveFile()?.extension === "canvas"
-			&& event.targetNode?.parentElement?.className === "canvas-node-content media-embed image-embed is-loaded") {
+			|| event.targetNode?.parentElement?.className === "canvas-node-content media-embed image-embed is-loaded") {
 			return;
 		}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -283,12 +283,10 @@ export default class CopyUrlInPreview extends Plugin {
 		const relativePath = getRelativePath(url, this.app);
 		menu.addSections(["open", "info", "system"]);
 		if (protocol === "app:" && relativePath) {
-			//open in new tab is natif to Obsidian, so no need to check if it's mobile supported :)
 			menu.addItem(item => setMenuItem(item, "open-in-new-tab")
 				.onClick(() => { openImageInNewTabFromEvent(this.app, event); })
 			);
 			if (Platform.isDesktop) {
-
 				menu.addItem(item => setMenuItem(item, "open-in-default-app")
 					.onClick(() => this.app.openWithDefaultApp(relativePath))
 				);

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,7 @@ export default class CopyUrlInPreview extends Plugin {
 	openPdfMenu?: Menu;
 	preventReopenPdfMenu: boolean;
 	lastHoveredLinkTarget: string;
-	otherMenu?: HTMLElement;
+	canvasCardMenu?: HTMLElement;
 
 	settings: CopyUrlInPreviewSettings;
 	async loadSettings() {
@@ -203,10 +203,10 @@ export default class CopyUrlInPreview extends Plugin {
 		}
 		//hide the menu on canvas
 		if (isInCanvas) {
-			const otherMenu = activeDocument.querySelector<HTMLElement>(".menu");
-			if (otherMenu) {
-				otherMenu.style.display = "none";
-				this.otherMenu = otherMenu;
+			const canvasCardMenu = activeDocument.querySelector<HTMLElement>(".menu");
+			if (canvasCardMenu) {
+				canvasCardMenu.style.display = "none";
+				this.canvasCardMenu = canvasCardMenu;
 			}
 		}
 		const menu = new Menu();
@@ -248,8 +248,8 @@ export default class CopyUrlInPreview extends Plugin {
 		if (this.openPdfMenu) {
 			this.openPdfMenu.hide();
 		}
-		if (this.otherMenu) {
-			this.otherMenu.style.display = "";
+		if (this.canvasCardMenu) {
+			this.canvasCardMenu.style.display = "";
 		}
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -297,7 +297,9 @@ export default class CopyUrlInPreview extends Plugin {
 		const imageElement = imageElementFromMouseEvent(event);
 		if (!imageElement) return;
 		// check if the image is on a canvas
-		if (!this.settings.enableDefaultOnCanvas && this.app.workspace.getActiveFile()?.extension === "canvas") {
+		if (!this.settings.enableDefaultOnCanvas && this.app.workspace.getActiveFile()?.extension === "canvas" 
+			&& event.targetNode?.parentElement?.className === "canvas-node-content media-embed image-embed is-loaded") 
+		{
 			return;
 		}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,11 +35,9 @@ export default class CopyUrlInPreview extends Plugin {
 			if (source === "canvas-menu" && file instanceof TFile && (file.extension.match(imageFileRegex) || file.extension === "pdf")
 			) {
 				menu.addItem(item => setMenuItem(item, "open-in-new-tab")
-					.setSection("open")
 					.onClick(() => { openTfileInNewTab(this.app, file); })
 				);
-				menu.addItem(item => setMenuItem(item, "copy-to-clipboard", this.app.vault.readBinary(file))
-					.setSection("info"))
+				menu.addItem(item => setMenuItem(item, "copy-to-clipboard", this.app.vault.readBinary(file)))
 			}
 		}));
 		this.registerEvent(this.app.workspace.on("canvas:node-menu", (menu, node: CanvasNodeWithUrl) => {
@@ -283,25 +281,21 @@ export default class CopyUrlInPreview extends Plugin {
 		event.preventDefault();
 		const menu = new Menu();
 		const relativePath = getRelativePath(url, this.app);
-		menu.addSections(["open", "copy", "system"]);
+		menu.addSections(["open", "info", "system"]);
 		if (protocol === "app:" && relativePath) {
 			//open in new tab is natif to Obsidian, so no need to check if it's mobile supported :)
 			menu.addItem(item => setMenuItem(item, "open-in-new-tab")
-				.setSection("open")
 				.onClick(() => { openImageInNewTabFromEvent(this.app, event); })
 			);
 			if (Platform.isDesktop) {
 
 				menu.addItem(item => setMenuItem(item, "open-in-default-app")
-					.setSection("system")
 					.onClick(() => this.app.openWithDefaultApp(relativePath))
 				);
 				menu.addItem(item => setMenuItem(item, "show-in-explorer")
-					.setSection("system")
 					.onClick(() => { this.app.showInFolder(relativePath); })
 				);
 				menu.addItem(item => setMenuItem(item, "reveal-in-navigation")
-					.setSection("system")
 					.onClick(() => {
 						const file = this.app.vault.getFileByPath(relativePath);
 						if (!file) {
@@ -313,8 +307,7 @@ export default class CopyUrlInPreview extends Plugin {
 				);
 			}
 		}
-		menu.addItem(item => setMenuItem(item, "copy-to-clipboard", image)
-			.setSection("copy"));
+		menu.addItem(item => setMenuItem(item, "copy-to-clipboard", image));
 		registerEscapeButton(menu);
 
 		menu.showAtPosition({ x: event.pageX, y: event.pageY });

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,16 @@ const deleteTempFileTimeout = 60_000;
 const OPEN_PDF_MENU_BORDER_SIZE = 100;
 const OPEN_PDF_MENU_TIMEOUT = 5_000;
 
+const strings = {
+	menuItems: {
+		copyImageToClipboard: "Copy image to clipboard"
+	},
+	messages : {
+		imageCopied: "Image copied to the clipboard!",
+		imageCopyFailed: "Error, could not copy the image!",
+	}
+}
+
 export default class CopyUrlInPreview extends Plugin {
 	longTapTimeoutId?: number;
 	openPdfMenu?: Menu;
@@ -45,17 +55,17 @@ export default class CopyUrlInPreview extends Plugin {
 					menu.addItem((item) => item
 						.setIcon("image-file")
 						.setSection("system")
-						.setTitle("Copy image to clipboard")
+						.setTitle(strings.menuItems.copyImageToClipboard)
 						.onClick(async () => {
 							const imageBuffer = await this.app.vault.readBinary(file);
 							const blob = new Blob([imageBuffer], { type: "image/png", });
 							try {
 								const data = new ClipboardItem({ [blob.type]: blob, });
 								await navigator.clipboard.write([data]);
-								new Notice("Image copied to the clipboard!", SUCCESS_NOTICE_TIMEOUT);
+								new Notice(strings.messages.imageCopied, SUCCESS_NOTICE_TIMEOUT);
 							} catch (e) {
 								console.log(e);
-								new Notice("Error, could not copy the image!");
+								new Notice(strings.messages.imageCopyFailed);
 							}
 						}));
 				}
@@ -71,15 +81,15 @@ export default class CopyUrlInPreview extends Plugin {
 					menu.addItem((item) => item
 						.setSection("canvas")
 						.setIcon("image-file")
-						.setTitle("Copy image to the clipboard")
+						.setTitle(strings.menuItems.copyImageToClipboard)
 						.onClick(async () => {
 							try {
 								const blob = await loadImageBlob(url);
 								const data = new ClipboardItem({ [blob.type]: blob, });
 								await navigator.clipboard.write([data]);
-								new Notice("Image copied to the clipboard!", SUCCESS_NOTICE_TIMEOUT);
+								new Notice(strings.messages.imageCopied, SUCCESS_NOTICE_TIMEOUT);
 							} catch {
-								new Notice("Error, could not copy the image!");
+								new Notice(strings.messages.imageCopyFailed);
 							}
 						}));
 
@@ -91,15 +101,15 @@ export default class CopyUrlInPreview extends Plugin {
 				if (url.match(/(avif|bmp|gif|jpe?g|png|svg|webp)$/gi)) {
 					menu.addItem((item) => item
 						.setIcon("image-file")
-						.setTitle("Copy image to clipboard")
+						.setTitle(strings.menuItems.copyImageToClipboard)
 						.onClick(async () => {
 							try {
 								const blob = await loadImageBlob(url);
 								const data = new ClipboardItem({ [blob.type]: blob, });
 								await navigator.clipboard.write([data]);
-								new Notice("Image copied to the clipboard!", SUCCESS_NOTICE_TIMEOUT);
+								new Notice(strings.messages.imageCopied, SUCCESS_NOTICE_TIMEOUT);
 							} catch {
-								new Notice("Error, could not copy the image!");
+								new Notice(strings.messages.imageCopyFailed);
 							}
 						}));
 				}
@@ -341,15 +351,15 @@ export default class CopyUrlInPreview extends Plugin {
 			case "https:":
 				menu.addItem((item: MenuItem) => item
 					.setIcon("image-file")
-					.setTitle("Copy image to clipboard")
+					.setTitle(strings.menuItems.copyImageToClipboard)
 					.onClick(async () => {
 						try {
 							const blob = await loadImageBlob(image);
 							const data = new ClipboardItem({ [blob.type]: blob });
 							await navigator.clipboard.write([data]);
-							new Notice("Image copied to the clipboard!", SUCCESS_NOTICE_TIMEOUT);
+							new Notice(strings.messages.imageCopied, SUCCESS_NOTICE_TIMEOUT);
 						} catch {
-							new Notice("Error, could not copy the image!");
+							new Notice(strings.messages.imageCopyFailed);
 						}
 					})
 				);

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ const strings = {
 	menuItems: {
 		copyImageToClipboard: "Copy image to clipboard"
 	},
-	messages : {
+	messages: {
 		imageCopied: "Image copied to the clipboard!",
 		imageCopyFailed: "Error, could not copy the image!",
 	}
@@ -37,6 +37,18 @@ export default class CopyUrlInPreview extends Plugin {
 	}
 	async saveSettings() {
 		await this.saveData(this.settings);
+	}
+
+	async copyImage(url: string | ArrayBuffer) {
+		const blob = url instanceof ArrayBuffer ? new Blob([url], { type: "image/png", }) : await loadImageBlob(url);
+		try {
+			const data = new ClipboardItem({ [blob.type]: blob, });
+			await navigator.clipboard.write([data]);
+			new Notice(strings.messages.imageCopied, SUCCESS_NOTICE_TIMEOUT);
+		} catch (e) {
+			console.log(e);
+			new Notice(strings.messages.imageCopyFailed);
+		}
 	}
 
 	async onload() {
@@ -57,16 +69,7 @@ export default class CopyUrlInPreview extends Plugin {
 						.setSection("system")
 						.setTitle(strings.menuItems.copyImageToClipboard)
 						.onClick(async () => {
-							const imageBuffer = await this.app.vault.readBinary(file);
-							const blob = new Blob([imageBuffer], { type: "image/png", });
-							try {
-								const data = new ClipboardItem({ [blob.type]: blob, });
-								await navigator.clipboard.write([data]);
-								new Notice(strings.messages.imageCopied, SUCCESS_NOTICE_TIMEOUT);
-							} catch (e) {
-								console.log(e);
-								new Notice(strings.messages.imageCopyFailed);
-							}
+							await this.copyImage(await this.app.vault.readBinary(file));
 						}));
 				}
 			})
@@ -83,14 +86,7 @@ export default class CopyUrlInPreview extends Plugin {
 						.setIcon("image-file")
 						.setTitle(strings.menuItems.copyImageToClipboard)
 						.onClick(async () => {
-							try {
-								const blob = await loadImageBlob(url);
-								const data = new ClipboardItem({ [blob.type]: blob, });
-								await navigator.clipboard.write([data]);
-								new Notice(strings.messages.imageCopied, SUCCESS_NOTICE_TIMEOUT);
-							} catch {
-								new Notice(strings.messages.imageCopyFailed);
-							}
+							await this.copyImage(url);
 						}));
 
 				}
@@ -103,14 +99,7 @@ export default class CopyUrlInPreview extends Plugin {
 						.setIcon("image-file")
 						.setTitle(strings.menuItems.copyImageToClipboard)
 						.onClick(async () => {
-							try {
-								const blob = await loadImageBlob(url);
-								const data = new ClipboardItem({ [blob.type]: blob, });
-								await navigator.clipboard.write([data]);
-								new Notice(strings.messages.imageCopied, SUCCESS_NOTICE_TIMEOUT);
-							} catch {
-								new Notice(strings.messages.imageCopyFailed);
-							}
+							await this.copyImage(url);
 						}));
 				}
 			})
@@ -353,14 +342,7 @@ export default class CopyUrlInPreview extends Plugin {
 					.setIcon("image-file")
 					.setTitle(strings.menuItems.copyImageToClipboard)
 					.onClick(async () => {
-						try {
-							const blob = await loadImageBlob(image);
-							const data = new ClipboardItem({ [blob.type]: blob });
-							await navigator.clipboard.write([data]);
-							new Notice(strings.messages.imageCopied, SUCCESS_NOTICE_TIMEOUT);
-						} catch {
-							new Notice(strings.messages.imageCopyFailed);
-						}
+						await this.copyImage(image);
 					})
 				);
 				if (protocol === "app:" && Platform.isDesktop) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,115 +60,84 @@ export default class CopyUrlInPreview extends Plugin {
 			this.registerDocument(window.document);
 		});
 		// register the image menu for canvas
-		this.registerEvent(
-			this.app.workspace.on("file-menu", (menu, file, source) => {
-				if (source === "canvas-menu"
-					&& file instanceof TFile
-					&& file.extension.match(/(avif|bmp|gif|jpe?g|png|svg|webp)/i)) {
-					menu.addItem((item) => item
-						.setIcon("image-file")
-						.setSection("system")
-						.setTitle(strings.menuItems.copyImageToClipboard)
-						.onClick(async () => {
-							await this.copyImage(await this.app.vault.readBinary(file));
-						}));
-				}
-			})
-		);
-		this.registerEvent(
-			this.app.workspace.on("canvas:node-menu", (menu, node: CanvasNodeWithUrl) => {
-				if (node.unknownData?.type === "link") {
-					const url = node.unknownData?.url;
-
-					menu.addItem((item) => item
-						.setSection("canvas")
-						.setIcon("image-file")
-						.setTitle(strings.menuItems.copyImageToClipboard)
-						.onClick(async () => {
-							await this.copyImage(url);
-						}));
-
-				}
-			})
-		);
-		this.registerEvent(
-			this.app.workspace.on("url-menu", (menu, url) => {
-				if (url.match(/(avif|bmp|gif|jpe?g|png|svg|webp)$/gi)) {
-					menu.addItem((item) => item
-						.setIcon("image-file")
-						.setTitle(strings.menuItems.copyImageToClipboard)
-						.onClick(async () => {
-							await this.copyImage(url);
-						}));
-				}
-			})
-		);
+		this.registerEvent(this.app.workspace.on("file-menu", (menu, file, source) => {
+			if (source === "canvas-menu" && file instanceof TFile
+				&& file.extension.match(/(avif|bmp|gif|jpe?g|png|svg|webp)/i)) {
+				menu.addItem((item) => item
+					.setIcon("image-file")
+					.setSection("system")
+					.setTitle(strings.menuItems.copyImageToClipboard)
+					.onClick(async () => { await this.copyImage(await this.app.vault.readBinary(file)); }));
+			}
+		}));
+		this.registerEvent(this.app.workspace.on("canvas:node-menu", (menu, node: CanvasNodeWithUrl) => {
+			if (node.unknownData?.type === "link") {
+				const url = node.unknownData?.url;
+				menu.addItem((item) => item
+					.setSection("canvas")
+					.setIcon("image-file")
+					.setTitle(strings.menuItems.copyImageToClipboard)
+					.onClick(async () => { await this.copyImage(url); }));
+			}
+		}));
+		this.registerEvent(this.app.workspace.on("url-menu", (menu, url) => {
+			if (url.match(/(avif|bmp|gif|jpe?g|png|svg|webp)$/gi)) {
+				menu.addItem((item) => item
+					.setIcon("image-file")
+					.setTitle(strings.menuItems.copyImageToClipboard)
+					.onClick(async () => {
+						await this.copyImage(url);
+					}));
+			}
+		}));
 	}
 
 	registerDocument(document: Document) {
-		this.register(
-			onElement(
-				document, "mouseover", ".pdf-embed iframe, .pdf-embed div.pdf-container, .workspace-leaf-content[data-type=pdf]",
-				this.showOpenPdfMenu.bind(this)
-			)
-		)
+		this.register(onElement(
+			document, "mouseover", ".pdf-embed iframe, .pdf-embed div.pdf-container, .workspace-leaf-content[data-type=pdf]",
+			this.showOpenPdfMenu.bind(this)
+		));
 
-		this.register(
-			onElement(
-				document, "mousemove", ".pdf-canvas",
-				this.showOpenPdfMenu.bind(this)
-			)
-		)
+		this.register(onElement(
+			document, "mousemove", ".pdf-canvas",
+			this.showOpenPdfMenu.bind(this)
+		));
 
 		if (Platform.isDesktop) {
-			this.register(
-				onElement(
-					document, "contextmenu", "img",
-					this.onImageContextMenu.bind(this)
-				)
-			);
+			this.register(onElement(
+				document, "contextmenu", "img",
+				this.onImageContextMenu.bind(this)
+			));
 
-			this.register(
-				onElement(
-					document, "mouseup", "img",
-					this.onImageMouseUp.bind(this)
-				)
-			);
+			this.register(onElement(
+				document, "mouseup", "img",
+				this.onImageMouseUp.bind(this)
+			));
 
-			this.register(
-				onElement(
-					document, "mouseover", ".cm-link, .cm-hmd-internal-link",
-					this.storeLastHoveredLinkInEditor.bind(this)
-				)
-			);
+			this.register(onElement(
+				document, "mouseover", ".cm-link, .cm-hmd-internal-link",
+				this.storeLastHoveredLinkInEditor.bind(this)
+			));
 
-			this.register(
-				onElement(
-					document, "mouseover", "a.internal-link",
-					this.storeLastHoveredLinkInPreview.bind(this)
-				)
-			);
+			this.register(onElement(
+				document, "mouseover", "a.internal-link",
+				this.storeLastHoveredLinkInPreview.bind(this)
+			));
 		} else {
-			this.register(
-				onElement(
-					document, "touchstart", "img",
-					this.startWaitingForLongTap.bind(this)
-				)
-			);
+			this.register(onElement(
+				document, "touchstart", "img",
+				this.startWaitingForLongTap.bind(this)
+			));
 
-			this.register(
-				onElement(
-					document, "touchend", "img",
-					this.stopWaitingForLongTap.bind(this)
-				)
-			);
+			this.register(onElement(
+				document, "touchend", "img",
+				this.stopWaitingForLongTap.bind(this)
+			));
 
-			this.register(
-				onElement(
-					document, "touchmove", "img",
-					this.stopWaitingForLongTap.bind(this)
-				)
-			);
+			this.register(onElement(
+				document, "touchmove", "img",
+				this.stopWaitingForLongTap.bind(this)
+			));
 		}
 	}
 
@@ -245,17 +214,15 @@ export default class CopyUrlInPreview extends Plugin {
 	}
 
 	registerEscapeButton(menu: Menu, document: Document = activeDocument) {
-		menu.register(
-			onElement(
-				document, "keydown", "*",
-				(e: KeyboardEvent) => {
-					if (e.key === "Escape") {
-						e.preventDefault();
-						e.stopPropagation();
-						menu.hide();
-					}
-				})
-		);
+		menu.register(onElement(
+			document, "keydown", "*",
+			(e: KeyboardEvent) => {
+				if (e.key === "Escape") {
+					e.preventDefault();
+					e.stopPropagation();
+					menu.hide();
+				}
+			}));
 	}
 
 	hideOpenPdfMenu() {
@@ -327,63 +294,52 @@ export default class CopyUrlInPreview extends Plugin {
 		if (!imageElement) return;
 		// check if the image is in canvas
 		if (this.app.workspace.getActiveFile()?.extension === "canvas") return;
-		event.preventDefault();
-		const menu = new Menu();
 		const image = imageElement.currentSrc;
 		const url = new URL(image);
 		const protocol = url.protocol;
-		switch (protocol) {
-			case "app:":
-			case "data:":
-			case "http:":
-			case "https:":
-				menu.addItem((item: MenuItem) => item
-					.setIcon("image-file")
-					.setTitle(strings.menuItems.copyImageToClipboard)
-					.onClick(async () => {
-						await this.copyImage(image);
-					})
-				);
-				if (protocol === "app:" && Platform.isDesktop) {
-					const relativePath = getRelativePath(url, this.app);
-					if (relativePath) {
-						menu.addItem((item: MenuItem) => item
-							.setIcon("arrow-up-right")
-							.setTitle("Open in new tab")
-							.onClick(() => {
-								openImageFromMouseEvent(event, this.app);
-							})
-						);
-						menu.addItem((item: MenuItem) => item
-							.setIcon("arrow-up-right")
-							.setTitle("Open in default app")
-							.onClick(() => this.app.openWithDefaultApp(relativePath))
-						);
-						menu.addItem((item: MenuItem) => item
-							.setIcon("arrow-up-right")
-							.setTitle(Platform.isMacOS ? "Reveal in Finder" : "Show in system explorer")
-							.onClick(() => {
-								this.app.showInFolder(relativePath);
-							})
-						);
-						menu.addItem((item: MenuItem) => item
-							.setIcon("folder")
-							.setTitle("Reveal file in navigation")
-							.onClick(() => {
-								const file = this.app.vault.getFileByPath(relativePath);
-								if (!file) {
-									console.warn(`getFileByPath returned null for ${relativePath}`);
-									return;
-								}
-								this.app.internalPlugins.getEnabledPluginById("file-explorer")?.revealInFolder(file);
-							})
-						);
+		const protocols = ["app:", "data:", "http:", "https:"];
+
+		if (!protocols.includes(protocol)) {
+			new Notice(`no handler for ${protocol} protocol`);
+			return;
+		}
+
+		event.preventDefault();
+		const menu = new Menu();
+		menu.addItem((item: MenuItem) => item
+			.setIcon("image-file")
+			.setTitle(strings.menuItems.copyImageToClipboard)
+			.onClick(async () => { await this.copyImage(image); })
+		);
+		const relativePath = getRelativePath(url, this.app);
+		if (protocol === "app:" && Platform.isDesktop && relativePath) {
+			menu.addItem((item: MenuItem) => item
+				.setIcon("arrow-up-right")
+				.setTitle("Open in new tab")
+				.onClick(() => { openImageFromMouseEvent(event, this.app); })
+			);
+			menu.addItem((item: MenuItem) => item
+				.setIcon("arrow-up-right")
+				.setTitle("Open in default app")
+				.onClick(() => this.app.openWithDefaultApp(relativePath))
+			);
+			menu.addItem((item: MenuItem) => item
+				.setIcon("arrow-up-right")
+				.setTitle(Platform.isMacOS ? "Reveal in Finder" : "Show in system explorer")
+				.onClick(() => { this.app.showInFolder(relativePath); })
+			);
+			menu.addItem((item: MenuItem) => item
+				.setIcon("folder")
+				.setTitle("Reveal file in navigation")
+				.onClick(() => {
+					const file = this.app.vault.getFileByPath(relativePath);
+					if (!file) {
+						console.warn(`getFileByPath returned null for ${relativePath}`);
+						return;
 					}
-				}
-				break;
-			default:
-				new Notice(`no handler for ${protocol} protocol`);
-				return;
+					this.app.internalPlugins.getEnabledPluginById("file-explorer")?.revealInFolder(file);
+				})
+			);
 		}
 
 		this.registerEscapeButton(menu);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { Menu, Plugin, Notice, Platform, TFile, MarkdownView } from "obsidian";
 import {
 	loadImageBlob, onElement, openImageInNewTabFromEvent, imageElementFromMouseEvent,
-	getRelativePath, timeouts, openTfileInNewTab, setMenuVisuals as setMenuItem, registerEscapeButton
+	getRelativePath, timeouts, openTfileInNewTab, setMenuItem, registerEscapeButton
 } from "./helpers";
 import { CanvasNodeWithUrl, FileSystemAdapterWithInternalApi, ElectronWindow } from "types";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,28 +1,11 @@
+import { Menu, Plugin, Notice, MenuItem, Platform, TFile, MarkdownView } from "obsidian";
 import {
-	Menu,
-	Plugin,
-	Notice,
-	MenuItem,
-	Platform,
-	TFile,
-	MarkdownView,
-} from "obsidian";
-import {
-	loadImageBlob,
-	onElement,
-	openImageFromMouseEvent,
-	ElectronWindow,
-	FileSystemAdapterWithInternalApi,
-	imageElementFromMouseEvent,
-	getRelativePath,
+	loadImageBlob, onElement, openImageFromMouseEvent,
+	ElectronWindow, FileSystemAdapterWithInternalApi, imageElementFromMouseEvent, getRelativePath,
 } from "./helpers";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import * as internal from "obsidian-typings";
-import {
-	CopyUrlInPreviewSettingTab,
-	CopyUrlInPreviewSettings,
-	DEFAULT_SETTINGS,
-} from "settings";
+import { CopyUrlInPreviewSettingTab, CopyUrlInPreviewSettings, DEFAULT_SETTINGS } from "settings";
 
 const IMAGE_URL_PREFIX = "/_capacitor_file_";
 const SUCCESS_NOTICE_TIMEOUT = 1_800;
@@ -39,9 +22,7 @@ export default class CopyUrlInPreview extends Plugin {
 
 	settings: CopyUrlInPreviewSettings;
 	async loadSettings() {
-		this.settings = Object.assign(
-			{},
-			DEFAULT_SETTINGS,
+		this.settings = Object.assign({}, DEFAULT_SETTINGS,
 			await this.loadData()
 		);
 	}
@@ -59,35 +40,24 @@ export default class CopyUrlInPreview extends Plugin {
 		//register the image menu for canvas
 		this.registerEvent(
 			this.app.workspace.on("file-menu", (menu, file, source) => {
-				if (
-					source === "canvas-menu" &&
-					file instanceof TFile &&
-					file.extension.match(/(avif|bmp|gif|jpe?g|png|svg|webp)/i)
-				) {
+				if (source === "canvas-menu"
+					&& file instanceof TFile
+					&& file.extension.match(/(avif|bmp|gif|jpe?g|png|svg|webp)/i)) {
 					menu.addItem((item) => {
-						item.setIcon("image-file")
+						item
+							.setIcon("image-file")
 							.setSection("system")
 							.setTitle("Copy image to clipboard")
 							.onClick(async () => {
-								const imageBuffer =
-									await this.app.vault.readBinary(file);
-								const blob = new Blob([imageBuffer], {
-									type: "image/png",
-								});
+								const imageBuffer = await this.app.vault.readBinary(file);
+								const blob = new Blob([imageBuffer], { type: "image/png", });
 								try {
-									const data = new ClipboardItem({
-										[blob.type]: blob,
-									});
+									const data = new ClipboardItem({ [blob.type]: blob, });
 									await navigator.clipboard.write([data]);
-									new Notice(
-										"Image copied to the clipboard!",
-										SUCCESS_NOTICE_TIMEOUT
-									);
+									new Notice("Image copied to the clipboard!", SUCCESS_NOTICE_TIMEOUT);
 								} catch (e) {
 									console.log(e);
-									new Notice(
-										"Error, could not copy the image!"
-									);
+									new Notice("Error, could not copy the image!");
 								}
 							});
 					});
@@ -108,18 +78,11 @@ export default class CopyUrlInPreview extends Plugin {
 							.onClick(async () => {
 								try {
 									const blob = await loadImageBlob(url);
-									const data = new ClipboardItem({
-										[blob.type]: blob,
-									});
+									const data = new ClipboardItem({ [blob.type]: blob, });
 									await navigator.clipboard.write([data]);
-									new Notice(
-										"Image copied to the clipboard!",
-										SUCCESS_NOTICE_TIMEOUT
-									);
+									new Notice("Image copied to the clipboard!", SUCCESS_NOTICE_TIMEOUT);
 								} catch {
-									new Notice(
-										"Error, could not copy the image!"
-									);
+									new Notice("Error, could not copy the image!");
 								}
 							});
 					});
@@ -135,18 +98,11 @@ export default class CopyUrlInPreview extends Plugin {
 							.onClick(async () => {
 								try {
 									const blob = await loadImageBlob(url);
-									const data = new ClipboardItem({
-										[blob.type]: blob,
-									});
+									const data = new ClipboardItem({ [blob.type]: blob, });
 									await navigator.clipboard.write([data]);
-									new Notice(
-										"Image copied to the clipboard!",
-										SUCCESS_NOTICE_TIMEOUT
-									);
+									new Notice("Image copied to the clipboard!", SUCCESS_NOTICE_TIMEOUT);
 								} catch {
-									new Notice(
-										"Error, could not copy the image!"
-									);
+									new Notice("Error, could not copy the image!");
 								}
 							});
 					});
@@ -162,18 +118,14 @@ export default class CopyUrlInPreview extends Plugin {
 	registerDocument(document: Document) {
 		this.register(
 			onElement(
-				document,
-				"mouseover",
-				".pdf-embed iframe, .pdf-embed div.pdf-container, .workspace-leaf-content[data-type=pdf]",
+				document, "mouseover", ".pdf-embed iframe, .pdf-embed div.pdf-container, .workspace-leaf-content[data-type=pdf]",
 				this.showOpenPdfMenu.bind(this)
 			)
 		);
 
 		this.register(
 			onElement(
-				document,
-				"mousemove",
-				".pdf-canvas",
+				document, "mousemove", ".pdf-canvas",
 				this.showOpenPdfMenu.bind(this)
 			)
 		);
@@ -181,63 +133,48 @@ export default class CopyUrlInPreview extends Plugin {
 		if (Platform.isDesktop) {
 			this.register(
 				onElement(
-					document,
-					"contextmenu",
-					"img",
+					document, "contextmenu", "img",
 					this.onImageContextMenu.bind(this)
 				)
 			);
 
 			this.register(
 				onElement(
-					document,
-					"mouseup",
-					"img",
+					document, "mouseup", "img",
 					this.onImageMouseUp.bind(this)
 				)
 			);
 
 			this.register(
 				onElement(
-					document,
-					"mouseover",
-					".cm-link, .cm-hmd-internal-link",
+					document, "mouseover", ".cm-link, .cm-hmd-internal-link",
 					this.storeLastHoveredLinkInEditor.bind(this)
 				)
 			);
 
 			this.register(
 				onElement(
-					document,
-					"mouseover",
-					"a.internal-link",
-					this.storeLastHoveredLinkInPreview.bind(this)
+					document, "mouseover", "a.internal-link", this.storeLastHoveredLinkInPreview.bind(this)
 				)
 			);
 		} else {
 			this.register(
 				onElement(
-					document,
-					"touchstart",
-					"img",
+					document, "touchstart", "img",
 					this.startWaitingForLongTap.bind(this)
 				)
 			);
 
 			this.register(
 				onElement(
-					document,
-					"touchend",
-					"img",
+					document, "touchend", "img",
 					this.stopWaitingForLongTap.bind(this)
 				)
 			);
 
 			this.register(
 				onElement(
-					document,
-					"touchmove",
-					"img",
+					document, "touchmove", "img",
 					this.stopWaitingForLongTap.bind(this)
 				)
 			);
@@ -263,21 +200,15 @@ export default class CopyUrlInPreview extends Plugin {
 	}
 
 	showOpenPdfMenu(event: MouseEvent | PointerEvent, el: HTMLElement) {
-		if (
-			!this.settings.pdfMenu ||
-			this.openPdfMenu ||
-			this.preventReopenPdfMenu
-		) {
+		if (!this.settings.pdfMenu || this.openPdfMenu || this.preventReopenPdfMenu) {
 			return;
 		}
 		if (this.app.workspace.getActiveFile()?.extension === "canvas") return;
 		const rect = el.getBoundingClientRect();
-		if (
-			rect.left + OPEN_PDF_MENU_BORDER_SIZE < event.x &&
-			event.x < rect.right - OPEN_PDF_MENU_BORDER_SIZE &&
-			rect.top + OPEN_PDF_MENU_BORDER_SIZE < event.y &&
-			event.y < rect.bottom - OPEN_PDF_MENU_BORDER_SIZE
-		) {
+		if (rect.left + OPEN_PDF_MENU_BORDER_SIZE < event.x
+			&& event.x < rect.right - OPEN_PDF_MENU_BORDER_SIZE
+			&& rect.top + OPEN_PDF_MENU_BORDER_SIZE < event.y
+			&& event.y < rect.bottom - OPEN_PDF_MENU_BORDER_SIZE) {
 			return;
 		}
 
@@ -287,17 +218,15 @@ export default class CopyUrlInPreview extends Plugin {
 			let pdfLink: string;
 			if (pdfEmbed.hasClass("popover")) {
 				pdfLink = this.lastHoveredLinkTarget;
-			} else {
+			}
+			else {
 				pdfLink = pdfEmbed.getAttr("src") ?? this.lastHoveredLinkTarget;
 			}
 
 			pdfLink = pdfLink?.replace(/#page=\d+$/, "");
 
 			const currentNotePath = this.app.workspace.getActiveFile()!.path;
-			pdfFile = this.app.metadataCache.getFirstLinkpathDest(
-				pdfLink!,
-				currentNotePath
-			)!;
+			pdfFile = this.app.metadataCache.getFirstLinkpathDest(pdfLink!, currentNotePath)!;
 		} else {
 			pdfFile = this.app.workspace.getActiveFile()!;
 		}
@@ -305,25 +234,19 @@ export default class CopyUrlInPreview extends Plugin {
 		const menu = new Menu();
 		this.registerEscapeButton(menu);
 		menu.onHide(() => (this.openPdfMenu = undefined));
-		menu.addItem((item: MenuItem) =>
-			item
-				.setIcon("pdf-file")
-				.setTitle("Open PDF externally")
-				.onClick(async () => {
-					this.preventReopenPdfMenu = true;
-					setTimeout(() => {
-						this.preventReopenPdfMenu = false;
-					}, OPEN_PDF_MENU_TIMEOUT);
-					this.hideOpenPdfMenu();
-					if (Platform.isDesktop) {
-						this.app.openWithDefaultApp(pdfFile.path);
-					} else {
-						await (
-							this.app.vault
-								.adapter as FileSystemAdapterWithInternalApi
-						).open(pdfFile.path);
-					}
-				})
+		menu.addItem((item: MenuItem) => item
+			.setIcon("pdf-file")
+			.setTitle("Open PDF externally")
+			.onClick(async () => {
+				this.preventReopenPdfMenu = true;
+				setTimeout(() => { this.preventReopenPdfMenu = false; }, OPEN_PDF_MENU_TIMEOUT);
+				this.hideOpenPdfMenu();
+				if (Platform.isDesktop) {
+					this.app.openWithDefaultApp(pdfFile.path);
+				} else {
+					await (this.app.vault.adapter as FileSystemAdapterWithInternalApi).open(pdfFile.path);
+				}
+			})
 		);
 		menu.showAtMouseEvent(event);
 		this.openPdfMenu = menu;
@@ -333,13 +256,15 @@ export default class CopyUrlInPreview extends Plugin {
 
 	registerEscapeButton(menu: Menu, document: Document = activeDocument) {
 		menu.register(
-			onElement(document, "keydown", "*", (e: KeyboardEvent) => {
-				if (e.key === "Escape") {
-					e.preventDefault();
-					e.stopPropagation();
-					menu.hide();
-				}
-			})
+			onElement(
+				document, "keydown", "*",
+				(e: KeyboardEvent) => {
+					if (e.key === "Escape") {
+						e.preventDefault();
+						e.stopPropagation();
+						menu.hide();
+					}
+				})
 		);
 	}
 
@@ -356,10 +281,7 @@ export default class CopyUrlInPreview extends Plugin {
 			this.longTapTimeoutId = undefined;
 		} else {
 			if (event.targetTouches.length == 1) {
-				this.longTapTimeoutId = window.setTimeout(
-					this.processLongTap.bind(this, event, img),
-					longTapTimeout
-				);
+				this.longTapTimeoutId = window.setTimeout(this.processLongTap.bind(this, event, img), longTapTimeout);
 			}
 		}
 	}
@@ -376,21 +298,14 @@ export default class CopyUrlInPreview extends Plugin {
 	async processLongTap(event: TouchEvent, img: HTMLImageElement) {
 		event.stopPropagation();
 		this.longTapTimeoutId = undefined;
-		const adapter = this.app.vault
-			.adapter as FileSystemAdapterWithInternalApi;
+		const adapter = this.app.vault.adapter as FileSystemAdapterWithInternalApi;
 		const electronWindow = window as unknown as ElectronWindow;
 		const basePath = adapter.getFullPath("");
 		const webviewServerUrl = electronWindow.WEBVIEW_SERVER_URL;
-		const localImagePrefixUrl =
-			webviewServerUrl + IMAGE_URL_PREFIX + basePath;
+		const localImagePrefixUrl = webviewServerUrl + IMAGE_URL_PREFIX + basePath;
 		if (img.src.startsWith(localImagePrefixUrl)) {
-			const encodedImageFileRelativePath = img.src.replace(
-				localImagePrefixUrl,
-				""
-			);
-			const imageFileRelativePath = decodeURIComponent(
-				encodedImageFileRelativePath
-			);
+			const encodedImageFileRelativePath = img.src.replace(localImagePrefixUrl, "");
+			const imageFileRelativePath = decodeURIComponent(encodedImageFileRelativePath);
 			await adapter.open(imageFileRelativePath);
 		} else {
 			try {
@@ -400,19 +315,12 @@ export default class CopyUrlInPreview extends Plugin {
 					return;
 				}
 				const extension = blob.type.replace("image/", "");
-				const randomGuid = window.URL.createObjectURL(new Blob([]))
-					.split("/")
-					.pop();
+				const randomGuid = window.URL.createObjectURL(new Blob([])).split("/").pop();
 				const tempFileName = `/.temp-${randomGuid}.${extension}`;
 				const buffer = await blob.arrayBuffer();
 				await adapter.writeBinary(tempFileName, buffer);
-				setTimeout(
-					() => adapter.remove(tempFileName),
-					deleteTempFileTimeout
-				);
-				new Notice(
-					"Image was temporarily saved and will be removed in 1 minute"
-				);
+				setTimeout(() => adapter.remove(tempFileName), deleteTempFileTimeout);
+				new Notice("Image was temporarily saved and will be removed in 1 minute");
 				await adapter.open(tempFileName);
 			} catch {
 				new Notice("Cannot open image");
@@ -441,76 +349,51 @@ export default class CopyUrlInPreview extends Plugin {
 			case "data:":
 			case "http:":
 			case "https:":
-				menu.addItem((item: MenuItem) =>
-					item
-						.setIcon("image-file")
-						.setTitle("Copy image to clipboard")
-						.onClick(async () => {
-							try {
-								const blob = await loadImageBlob(image);
-								const data = new ClipboardItem({
-									[blob.type]: blob,
-								});
-								await navigator.clipboard.write([data]);
-								new Notice(
-									"Image copied to the clipboard!",
-									SUCCESS_NOTICE_TIMEOUT
-								);
-							} catch {
-								new Notice("Error, could not copy the image!");
-							}
-						})
+				menu.addItem((item: MenuItem) => item
+					.setIcon("image-file")
+					.setTitle("Copy image to clipboard")
+					.onClick(async () => {
+						try {
+							const blob = await loadImageBlob(image);
+							const data = new ClipboardItem({ [blob.type]: blob });
+							await navigator.clipboard.write([data]);
+							new Notice("Image copied to the clipboard!", SUCCESS_NOTICE_TIMEOUT);
+						} catch {
+							new Notice("Error, could not copy the image!");
+						}
+					})
 				);
 				if (protocol === "app:" && Platform.isDesktop) {
 					const relativePath = getRelativePath(url, this.app);
 					if (relativePath) {
-						menu.addItem((item: MenuItem) =>
-							item
-								.setIcon("arrow-up-right")
-								.setTitle("Open in new tab")
-								.onClick(() => {
-									openImageFromMouseEvent(event, this.app);
-								})
+						menu.addItem((item: MenuItem) => item
+							.setIcon("arrow-up-right")
+							.setTitle("Open in new tab")
+							.onClick(() => { openImageFromMouseEvent(event, this.app); })
 						);
-						menu.addItem((item: MenuItem) =>
-							item
-								.setIcon("arrow-up-right")
-								.setTitle("Open in default app")
-								.onClick(() =>
-									this.app.openWithDefaultApp(relativePath)
-								)
+						menu.addItem((item: MenuItem) => item
+							.setIcon("arrow-up-right")
+							.setTitle("Open in default app")
+							.onClick(() => this.app.openWithDefaultApp(relativePath))
 						);
-						menu.addItem((item: MenuItem) =>
-							item
-								.setIcon("arrow-up-right")
-								.setTitle(
-									Platform.isMacOS
-										? "Reveal in Finder"
-										: "Show in system explorer"
-								)
-								.onClick(() => {
-									this.app.showInFolder(relativePath);
-								})
+						menu.addItem((item: MenuItem) => item
+							.setIcon("arrow-up-right")
+							.setTitle(
+								Platform.isMacOS ? "Reveal in Finder" : "Show in system explorer"
+							)
+							.onClick(() => { this.app.showInFolder(relativePath); })
 						);
-						menu.addItem((item: MenuItem) =>
-							item
-								.setIcon("folder")
-								.setTitle("Reveal file in navigation")
-								.onClick(() => {
-									const file =
-										this.app.vault.getFileByPath(
-											relativePath
-										);
-									if (!file) {
-										console.warn(
-											`getFileByPath returned null for ${relativePath}`
-										);
-										return;
-									}
-									this.app.internalPlugins
-										.getEnabledPluginById("file-explorer")
-										?.revealInFolder(file);
-								})
+						menu.addItem((item: MenuItem) => item
+							.setIcon("folder")
+							.setTitle("Reveal file in navigation")
+							.onClick(() => {
+								const file = this.app.vault.getFileByPath(relativePath);
+								if (!file) {
+									console.warn(`getFileByPath returned null for ${relativePath}`);
+									return;
+								}
+								this.app.internalPlugins.getEnabledPluginById("file-explorer")?.revealInFolder(file);
+							})
 						);
 					}
 				}
@@ -528,10 +411,7 @@ export default class CopyUrlInPreview extends Plugin {
 
 	onImageMouseUp(event: MouseEvent) {
 		const middleButtonNumber = 1;
-		if (
-			event.button == middleButtonNumber &&
-			this.settings.middleClickNewTab
-		) {
+		if (event.button == middleButtonNumber && this.settings.middleClickNewTab) {
 			openImageFromMouseEvent(event, this.app);
 		}
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,8 +32,8 @@ export default class CopyUrlInPreview extends Plugin {
 		});
 		// register the image menu for canvas
 		this.registerEvent(this.app.workspace.on("file-menu", (menu, file, source) => {
-			if (source === "canvas-menu" && file instanceof TFile && (file.extension.match(imageFileRegex) || file.extension === "pdf")
-			) {
+			if (source === "canvas-menu" && file instanceof TFile
+				&& (file.extension.match(imageFileRegex) || file.extension === "pdf")) {
 				menu.addItem(item => setMenuItem(item, "open-in-new-tab")
 					.onClick(() => { openTfileInNewTab(this.app, file); })
 				);

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,9 @@ export default class CopyUrlInPreview extends Plugin {
 	}
 
 	async copyImageToClipboard(url: string | ArrayBuffer) {
-		const blob = url instanceof ArrayBuffer ? new Blob([url], { type: "image/png", }) : await loadImageBlob(url);
+		const blob = url instanceof ArrayBuffer
+			? new Blob([url], { type: "image/png", })
+			: await loadImageBlob(url);
 		try {
 			const data = new ClipboardItem({ [blob.type]: blob, });
 			await navigator.clipboard.write([data]);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,7 @@ import { Menu, Plugin, Notice, MenuItem, Platform, TFile, MarkdownView } from "o
 import {
 	loadImageBlob, onElement, openImageFromMouseEvent,
 	ElectronWindow, FileSystemAdapterWithInternalApi,
-	imageElementFromMouseEvent, getRelativePath,
-	CanvasNodeWithUrl
+	imageElementFromMouseEvent, getRelativePath, CanvasNodeWithUrl
 } from "./helpers"
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import * as internal from 'obsidian-typings';
@@ -40,14 +39,14 @@ export default class CopyUrlInPreview extends Plugin {
 		await this.saveData(this.settings);
 	}
 
-	async copyImage(url: string | ArrayBuffer) {
+	async copyImageToClipboard(url: string | ArrayBuffer) {
 		const blob = url instanceof ArrayBuffer ? new Blob([url], { type: "image/png", }) : await loadImageBlob(url);
 		try {
 			const data = new ClipboardItem({ [blob.type]: blob, });
 			await navigator.clipboard.write([data]);
 			new Notice(strings.messages.imageCopied, SUCCESS_NOTICE_TIMEOUT);
 		} catch (e) {
-			console.log(e);
+			console.error(e);
 			new Notice(strings.messages.imageCopyFailed);
 		}
 	}
@@ -67,7 +66,7 @@ export default class CopyUrlInPreview extends Plugin {
 					.setIcon("image-file")
 					.setSection("system")
 					.setTitle(strings.menuItems.copyImageToClipboard)
-					.onClick(async () => { await this.copyImage(await this.app.vault.readBinary(file)); }));
+					.onClick(async () => { await this.copyImageToClipboard(await this.app.vault.readBinary(file)); }));
 			}
 		}));
 		this.registerEvent(this.app.workspace.on("canvas:node-menu", (menu, node: CanvasNodeWithUrl) => {
@@ -77,7 +76,7 @@ export default class CopyUrlInPreview extends Plugin {
 					.setSection("canvas")
 					.setIcon("image-file")
 					.setTitle(strings.menuItems.copyImageToClipboard)
-					.onClick(async () => { await this.copyImage(url); }));
+					.onClick(async () => { await this.copyImageToClipboard(url); }));
 			}
 		}));
 		this.registerEvent(this.app.workspace.on("url-menu", (menu, url) => {
@@ -86,7 +85,7 @@ export default class CopyUrlInPreview extends Plugin {
 					.setIcon("image-file")
 					.setTitle(strings.menuItems.copyImageToClipboard)
 					.onClick(async () => {
-						await this.copyImage(url);
+						await this.copyImageToClipboard(url);
 					}));
 			}
 		}));
@@ -315,7 +314,7 @@ export default class CopyUrlInPreview extends Plugin {
 		menu.addItem((item: MenuItem) => item
 			.setIcon("image-file")
 			.setTitle(strings.menuItems.copyImageToClipboard)
-			.onClick(async () => { await this.copyImage(image); })
+			.onClick(async () => { await this.copyImageToClipboard(image); })
 		);
 		const relativePath = getRelativePath(url, this.app);
 		if (protocol === "app:" && Platform.isDesktop && relativePath) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,11 @@
 import { Menu, Plugin, Notice, MenuItem, Platform, TFile, MarkdownView } from "obsidian";
 import {
 	loadImageBlob, onElement, openImageFromMouseEvent,
-	ElectronWindow, FileSystemAdapterWithInternalApi, imageElementFromMouseEvent, getRelativePath,
-} from "./helpers";
+	ElectronWindow, FileSystemAdapterWithInternalApi,
+	imageElementFromMouseEvent, getRelativePath
+} from "./helpers"
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import * as internal from "obsidian-typings";
+import * as internal from 'obsidian-typings';
 import { CopyUrlInPreviewSettingTab, CopyUrlInPreviewSettings, DEFAULT_SETTINGS } from "settings";
 
 const IMAGE_URL_PREFIX = "/_capacitor_file_";
@@ -22,9 +23,7 @@ export default class CopyUrlInPreview extends Plugin {
 
 	settings: CopyUrlInPreviewSettings;
 	async loadSettings() {
-		this.settings = Object.assign({}, DEFAULT_SETTINGS,
-			await this.loadData()
-		);
+		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
 	}
 	async saveSettings() {
 		await this.saveData(this.settings);
@@ -43,24 +42,22 @@ export default class CopyUrlInPreview extends Plugin {
 				if (source === "canvas-menu"
 					&& file instanceof TFile
 					&& file.extension.match(/(avif|bmp|gif|jpe?g|png|svg|webp)/i)) {
-					menu.addItem((item) => {
-						item
-							.setIcon("image-file")
-							.setSection("system")
-							.setTitle("Copy image to clipboard")
-							.onClick(async () => {
-								const imageBuffer = await this.app.vault.readBinary(file);
-								const blob = new Blob([imageBuffer], { type: "image/png", });
-								try {
-									const data = new ClipboardItem({ [blob.type]: blob, });
-									await navigator.clipboard.write([data]);
-									new Notice("Image copied to the clipboard!", SUCCESS_NOTICE_TIMEOUT);
-								} catch (e) {
-									console.log(e);
-									new Notice("Error, could not copy the image!");
-								}
-							});
-					});
+					menu.addItem((item) => item
+						.setIcon("image-file")
+						.setSection("system")
+						.setTitle("Copy image to clipboard")
+						.onClick(async () => {
+							const imageBuffer = await this.app.vault.readBinary(file);
+							const blob = new Blob([imageBuffer], { type: "image/png", });
+							try {
+								const data = new ClipboardItem({ [blob.type]: blob, });
+								await navigator.clipboard.write([data]);
+								new Notice("Image copied to the clipboard!", SUCCESS_NOTICE_TIMEOUT);
+							} catch (e) {
+								console.log(e);
+								new Notice("Error, could not copy the image!");
+							}
+						}));
 				}
 			})
 		);
@@ -71,41 +68,40 @@ export default class CopyUrlInPreview extends Plugin {
 					//@ts-ignore
 					const url = node.unknownData?.url;
 
-					menu.addItem((item) => {
-						item.setSection("canvas")
-							.setIcon("image-file")
-							.setTitle("Copy image to the clipboard")
-							.onClick(async () => {
-								try {
-									const blob = await loadImageBlob(url);
-									const data = new ClipboardItem({ [blob.type]: blob, });
-									await navigator.clipboard.write([data]);
-									new Notice("Image copied to the clipboard!", SUCCESS_NOTICE_TIMEOUT);
-								} catch {
-									new Notice("Error, could not copy the image!");
-								}
-							});
-					});
+					menu.addItem((item) => item
+						.setSection("canvas")
+						.setIcon("image-file")
+						.setTitle("Copy image to the clipboard")
+						.onClick(async () => {
+							try {
+								const blob = await loadImageBlob(url);
+								const data = new ClipboardItem({ [blob.type]: blob, });
+								await navigator.clipboard.write([data]);
+								new Notice("Image copied to the clipboard!", SUCCESS_NOTICE_TIMEOUT);
+							} catch {
+								new Notice("Error, could not copy the image!");
+							}
+						}));
+
 				}
 			})
 		);
 		this.registerEvent(
 			this.app.workspace.on("url-menu", (menu, url) => {
 				if (url.match(/(avif|bmp|gif|jpe?g|png|svg|webp)$/gi)) {
-					menu.addItem((item) => {
-						item.setIcon("image-file")
-							.setTitle("Copy image to clipboard")
-							.onClick(async () => {
-								try {
-									const blob = await loadImageBlob(url);
-									const data = new ClipboardItem({ [blob.type]: blob, });
-									await navigator.clipboard.write([data]);
-									new Notice("Image copied to the clipboard!", SUCCESS_NOTICE_TIMEOUT);
-								} catch {
-									new Notice("Error, could not copy the image!");
-								}
-							});
-					});
+					menu.addItem((item) => item
+						.setIcon("image-file")
+						.setTitle("Copy image to clipboard")
+						.onClick(async () => {
+							try {
+								const blob = await loadImageBlob(url);
+								const data = new ClipboardItem({ [blob.type]: blob, });
+								await navigator.clipboard.write([data]);
+								new Notice("Image copied to the clipboard!", SUCCESS_NOTICE_TIMEOUT);
+							} catch {
+								new Notice("Error, could not copy the image!");
+							}
+						}));
 				}
 			})
 		);
@@ -121,14 +117,14 @@ export default class CopyUrlInPreview extends Plugin {
 				document, "mouseover", ".pdf-embed iframe, .pdf-embed div.pdf-container, .workspace-leaf-content[data-type=pdf]",
 				this.showOpenPdfMenu.bind(this)
 			)
-		);
+		)
 
 		this.register(
 			onElement(
 				document, "mousemove", ".pdf-canvas",
 				this.showOpenPdfMenu.bind(this)
 			)
-		);
+		)
 
 		if (Platform.isDesktop) {
 			this.register(
@@ -154,7 +150,8 @@ export default class CopyUrlInPreview extends Plugin {
 
 			this.register(
 				onElement(
-					document, "mouseover", "a.internal-link", this.storeLastHoveredLinkInPreview.bind(this)
+					document, "mouseover", "a.internal-link",
+					this.storeLastHoveredLinkInPreview.bind(this)
 				)
 			);
 		} else {
@@ -182,8 +179,7 @@ export default class CopyUrlInPreview extends Plugin {
 	}
 
 	storeLastHoveredLinkInEditor(event: MouseEvent) {
-		const editor =
-			this.app.workspace.getActiveViewOfType(MarkdownView)?.editor;
+		const editor = this.app.workspace.getActiveViewOfType(MarkdownView)?.editor;
 		if (!editor) {
 			return;
 		}
@@ -223,7 +219,7 @@ export default class CopyUrlInPreview extends Plugin {
 				pdfLink = pdfEmbed.getAttr("src") ?? this.lastHoveredLinkTarget;
 			}
 
-			pdfLink = pdfLink?.replace(/#page=\d+$/, "");
+			pdfLink = pdfLink?.replace(/#page=\d+$/, '');
 
 			const currentNotePath = this.app.workspace.getActiveFile()!.path;
 			pdfFile = this.app.metadataCache.getFirstLinkpathDest(pdfLink!, currentNotePath)!;
@@ -233,7 +229,7 @@ export default class CopyUrlInPreview extends Plugin {
 
 		const menu = new Menu();
 		this.registerEscapeButton(menu);
-		menu.onHide(() => (this.openPdfMenu = undefined));
+		menu.onHide(() => this.openPdfMenu = undefined);
 		menu.addItem((item: MenuItem) => item
 			.setIcon("pdf-file")
 			.setTitle("Open PDF externally")
@@ -369,7 +365,9 @@ export default class CopyUrlInPreview extends Plugin {
 						menu.addItem((item: MenuItem) => item
 							.setIcon("arrow-up-right")
 							.setTitle("Open in new tab")
-							.onClick(() => { openImageFromMouseEvent(event, this.app); })
+							.onClick(() => {
+								openImageFromMouseEvent(event, this.app);
+							})
 						);
 						menu.addItem((item: MenuItem) => item
 							.setIcon("arrow-up-right")
@@ -378,10 +376,10 @@ export default class CopyUrlInPreview extends Plugin {
 						);
 						menu.addItem((item: MenuItem) => item
 							.setIcon("arrow-up-right")
-							.setTitle(
-								Platform.isMacOS ? "Reveal in Finder" : "Show in system explorer"
-							)
-							.onClick(() => { this.app.showInFolder(relativePath); })
+							.setTitle(Platform.isMacOS ? "Reveal in Finder" : "Show in system explorer")
+							.onClick(() => {
+								this.app.showInFolder(relativePath);
+							})
 						);
 						menu.addItem((item: MenuItem) => item
 							.setIcon("folder")

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,8 @@ import { Menu, Plugin, Notice, MenuItem, Platform, TFile, MarkdownView } from "o
 import {
 	loadImageBlob, onElement, openImageFromMouseEvent,
 	ElectronWindow, FileSystemAdapterWithInternalApi,
-	imageElementFromMouseEvent, getRelativePath
+	imageElementFromMouseEvent, getRelativePath,
+	CanvasNodeWithUrl
 } from "./helpers"
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import * as internal from 'obsidian-typings';
@@ -75,10 +76,8 @@ export default class CopyUrlInPreview extends Plugin {
 			})
 		);
 		this.registerEvent(
-			this.app.workspace.on("canvas:node-menu", (menu, node) => {
-				//@ts-ignore
+			this.app.workspace.on("canvas:node-menu", (menu, node: CanvasNodeWithUrl) => {
 				if (node.unknownData?.type === "link") {
-					//@ts-ignore
 					const url = node.unknownData?.url;
 
 					menu.addItem((item) => item

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ export default class CopyUrlInPreview extends Plugin {
 		this.app.workspace.on("window-open", (_workspaceWindow, window) => {
 			this.registerDocument(window.document);
 		});
-		//register the image menu for canvas
+		// register the image menu for canvas
 		this.registerEvent(
 			this.app.workspace.on("file-menu", (menu, file, source) => {
 				if (source === "canvas-menu"
@@ -331,10 +331,8 @@ export default class CopyUrlInPreview extends Plugin {
 	onImageContextMenu(event: MouseEvent) {
 		const imageElement = imageElementFromMouseEvent(event);
 		if (!imageElement) return;
-		//check if the image is in canvas
-		if (this.app.workspace.getActiveFile()?.extension === "canvas") {
-			return;
-		}
+		// check if the image is in canvas
+		if (this.app.workspace.getActiveFile()?.extension === "canvas") return;
 		event.preventDefault();
 		const menu = new Menu();
 		const image = imageElement.currentSrc;

--- a/src/main.ts
+++ b/src/main.ts
@@ -126,6 +126,33 @@ export default class CopyUrlInPreview extends Plugin {
 				}
 			})
 		);
+		this.registerEvent(
+			this.app.workspace.on("url-menu", (menu, url) => {
+				if (url.match(/(avif|bmp|gif|jpe?g|png|svg|webp)$/gi)) {
+					menu.addItem((item) => {
+						item.setIcon("image-file")
+							.setTitle("Copy image to clipboard")
+							.onClick(async () => {
+								try {
+									const blob = await loadImageBlob(url);
+									const data = new ClipboardItem({
+										[blob.type]: blob,
+									});
+									await navigator.clipboard.write([data]);
+									new Notice(
+										"Image copied to the clipboard!",
+										SUCCESS_NOTICE_TIMEOUT
+									);
+								} catch {
+									new Notice(
+										"Error, could not copy the image!"
+									);
+								}
+							});
+					});
+				}
+			})
+		);
 	}
 
 	onunload(): void {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,11 +4,13 @@ import { App, PluginSettingTab, Setting } from "obsidian";
 export interface CopyUrlInPreviewSettings {
     pdfMenu: boolean;
     middleClickNewTab: boolean;
+    enableDefaultOnCanvas: boolean;
 }
 
 export const DEFAULT_SETTINGS: CopyUrlInPreviewSettings = {
     pdfMenu: false,
-    middleClickNewTab: true
+    middleClickNewTab: true,
+    enableDefaultOnCanvas: false
 }
 
 export class CopyUrlInPreviewSettingTab extends PluginSettingTab {
@@ -34,6 +36,16 @@ export class CopyUrlInPreviewSettingTab extends PluginSettingTab {
             .addToggle((toggle) => {
                 toggle.setValue(this.plugin.settings.middleClickNewTab).onChange((value) => {
                     this.plugin.settings.middleClickNewTab = value;
+                    this.plugin.saveSettings();
+                });
+            })
+        new Setting(containerEl)
+            .setName("Enable regular context menu on canvas")
+            .setDesc("The regular context menu sometimes duplicates the context menu on the canvas, so it's disabled there by default.\n"
+                + "There is a separate context menu for images directly on the canvas, but if that's not enough (for example for images in notes on canvas), you can enable the regular context menu here too.")
+            .addToggle((toggle) => {
+                toggle.setValue(this.plugin.settings.enableDefaultOnCanvas).onChange((value) => {
+                    this.plugin.settings.enableDefaultOnCanvas = value;
                     this.plugin.saveSettings();
                 });
             })

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,20 @@
+import { CanvasNode, FileSystemAdapter } from "obsidian"
+
+export interface ElectronWindow extends Window {
+    WEBVIEW_SERVER_URL: string
+}
+
+export interface FileSystemAdapterWithInternalApi extends FileSystemAdapter {
+    open(path: string): Promise<void>
+}
+
+export interface CanvasNodeWithUrl extends CanvasNode {
+    unknownData: {
+        url: string
+        type: string
+    }
+}
+
+export interface Listener {
+    (this: Document, ev: Event): unknown;
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,5 @@
 import { CanvasNode, FileSystemAdapter } from "obsidian"
+import type { i18n } from "i18next";
 
 export interface ElectronWindow extends Window {
     WEBVIEW_SERVER_URL: string
@@ -17,4 +18,8 @@ export interface CanvasNodeWithUrl extends CanvasNode {
 
 export interface Listener {
     (this: Document, ev: Event): unknown;
+}
+
+declare global {
+    const i18next: i18n;
 }


### PR DESCRIPTION
The duplicate menu on canvas bored me a lot, so I removed it from the canvas, and added the option for copy directly in the context menu on canvas card.

For external image, I do the same but I use the node-menu.

I only added support for copy as other option are already supported by Obsidian & canvas.

Moreover, I made also a temporary fix for #35 with adding the copy option in the url-menu.
Also fix #39 

Pretty sorry for the whitespace and some other things. As you didn't set anything about formatting in eslint, my default settings overriding your writing.
