### PR TITLE
REFACT: Move 'menu' from helpers.ts to menu.ts

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,4 @@
-import { type App, type MenuItem, Notice, normalizePath, Platform, type TFile } from "obsidian";
+import { type App, Notice, normalizePath, type TFile } from "obsidian";
 
 export const timeouts = {
     loadImageBlob: 5_000,
@@ -115,62 +115,4 @@ export function getTfileFromUrl(app: App, url: URL): TFile | null {
 
 export function openTfileInNewTab(app: App, tfile: TFile): void {
     void app.workspace.getLeaf(true).openFile(tfile, { active: true });
-}
-
-type MenuType =
-    | "open-in-new-tab"
-    | "copy-to-clipboard"
-    | "open-in-default-app"
-    | "show-in-explorer"
-    | "reveal-in-navigation"
-    | "reveal-in-navigation-tree"
-    | "rename-file";
-
-export function setMenuItem(
-    item: MenuItem,
-    type: "copy-to-clipboard",
-    imageSource: string | Promise<ArrayBuffer>,
-): MenuItem;
-export function setMenuItem(item: MenuItem, type: MenuType): MenuItem;
-export function setMenuItem(
-    item: MenuItem,
-    type: MenuType,
-    imageSource?: string | Promise<ArrayBuffer>,
-): MenuItem {
-    const types: Record<MenuType, { icon: string; title: string; section: "info" | "system" | "open" }> = {
-        "copy-to-clipboard": { section: "info", icon: "image-file", title: "interface.label-copy" },
-        "open-in-new-tab": { section: "open", icon: "file-plus", title: "interface.menu.open-in-new-tab" },
-        "open-in-default-app": {
-            section: "system",
-            icon: "arrow-up-right",
-            title: "plugins.open-with-default-app.action-open-file",
-        },
-        "show-in-explorer": {
-            section: "system",
-            icon: "arrow-up-right",
-            title: `plugins.open-with-default-app.action-show-in-folder${Platform.isMacOS ? "-mac" : ""}`,
-        },
-        "reveal-in-navigation": {
-            section: "system",
-            icon: "folder",
-            title: "plugins.file-explorer.action-reveal-file",
-        },
-        "reveal-in-navigation-tree": {
-            section: "system",
-            icon: "folder",
-            title: "Reveal in File Tree Alternative",
-        },
-        "rename-file": { section: "info", icon: "pencil", title: "interface.menu.rename" },
-    };
-
-    if (type === "copy-to-clipboard" && imageSource) {
-        item.onClick(async () => {
-            await copyImageToClipboard(typeof imageSource === "string" ? imageSource : await imageSource);
-        });
-    }
-
-    return item
-        .setIcon(types[type].icon)
-        .setTitle(i18next.t(types[type].title))
-        .setSection(types[type].section);
 }

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -1,0 +1,51 @@
+import { MenuItem, Platform } from "obsidian";
+
+type ItemType =
+    | "open-in-new-tab"
+    | "copy-to-clipboard"
+    | "open-in-default-app"
+    | "show-in-explorer"
+    | "reveal-in-navigation"
+    | "reveal-in-navigation-tree"
+    | "rename-file";
+
+type Section = "info" | "system" | "open";
+
+interface Item {
+    section: Section;
+    icon: string;
+    title: string;
+}
+
+const types: Record<ItemType, Item> = {
+    "copy-to-clipboard": { section: "info", icon: "image-file", title: "interface.label-copy" },
+    "open-in-new-tab": { section: "open", icon: "file-plus", title: "interface.menu.open-in-new-tab" },
+    "open-in-default-app": {
+        section: "system",
+        icon: "arrow-up-right",
+        title: "plugins.open-with-default-app.action-open-file",
+    },
+    "show-in-explorer": {
+        section: "system",
+        icon: "arrow-up-right",
+        title: `plugins.open-with-default-app.action-show-in-folder${Platform.isMacOS ? "-mac" : ""}`,
+    },
+    "reveal-in-navigation": {
+        section: "system",
+        icon: "folder",
+        title: "plugins.file-explorer.action-reveal-file",
+    },
+    "reveal-in-navigation-tree": {
+        section: "system",
+        icon: "folder",
+        title: "Reveal in File Tree Alternative",
+    },
+    "rename-file": { section: "info", icon: "pencil", title: "interface.menu.rename" },
+};
+
+export function setItem(item: MenuItem, type: ItemType): MenuItem {
+    return item
+        .setIcon(types[type].icon)
+        .setTitle(i18next.t(types[type].title))
+        .setSection(types[type].section);
+}

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -1,4 +1,4 @@
-import { MenuItem, Platform } from "obsidian";
+import { type IconName, type MenuItem, Platform } from "obsidian";
 
 type ItemType =
     | "open-in-new-tab"
@@ -13,7 +13,7 @@ type Section = "info" | "system" | "open";
 
 interface Item {
     section: Section;
-    icon: string;
+    icon: IconName;
     title: string;
 }
 


### PR DESCRIPTION
I think the "menu functionality" should stay in a separate file. It's long, have many types and is confuse add new items with the current structure.

This PR moves the menu code to `menu.ts`, also I made some changes:

- Rename `setMenuItem()` to `setItem()` for align with `Menu` method `addItem()`.
- Avoid handle `copy-to-clipboard` inside `setItem()`. Instead should be handled by the `onClick()` method for flexibility and consistency.