### PR TITLE
Reuse Sections as array

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -131,7 +131,7 @@ export default class CopyUrlInPreview extends Plugin {
         const menu = new Menu();
         const internalFile = getTfileFromUrl(this.app, url);
 
-        menu.addSections(MENU_SECTIONS as unknown as string[]);
+        menu.addSections(Array.from(MENU_SECTIONS));
 
         if (internalFile) {
             menu.addItem((item) =>

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import {
     onElementToOff,
     openTfileInNewTab,
 } from "./helpers";
-import { setItem } from "./menu";
+import { MENU_SECTIONS, setItem } from "./menu";
 import { type CopyUrlInPreviewSettings, CopyUrlInPreviewSettingTab, DEFAULT_SETTINGS } from "./settings";
 import type { CanvasNodeWithUrl } from "./types";
 
@@ -131,7 +131,7 @@ export default class CopyUrlInPreview extends Plugin {
         const menu = new Menu();
         const internalFile = getTfileFromUrl(this.app, url);
 
-        menu.addSections(["file", "open", "info", "system"]);
+        menu.addSections(MENU_SECTIONS as unknown as string[]);
 
         if (internalFile) {
             menu.addItem((item) =>

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -9,10 +9,10 @@ type ItemType =
     | "reveal-in-navigation-tree"
     | "rename-file";
 
-type Section = "info" | "system" | "open";
+export const MENU_SECTIONS = ["file", "open", "info", "system"] as const;
 
 interface Item {
-    section: Section;
+    section: (typeof MENU_SECTIONS)[number];
     icon: IconName;
     title: string;
 }
@@ -45,7 +45,7 @@ const types: Record<ItemType, Item> = {
 
 export function setItem(item: MenuItem, type: ItemType): MenuItem {
     return item
+        .setSection(types[type].section)
         .setIcon(types[type].icon)
-        .setTitle(i18next.t(types[type].title))
-        .setSection(types[type].section);
+        .setTitle(i18next.t(types[type].title));
 }


### PR DESCRIPTION
With the old way is needed maintain the list of menu sections as type and array, so is easy to forget add a section to both places.

This PR allows get type hinting of menu sections and reuse it as array for `menu.addSections`. The solution is very hacky but does the job.

---

Also just a preference, I reordered the function `setItem` just to match with `Item` interface.