### PR TITLE
Refact: Copy image helpers

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -31,9 +31,10 @@ export function withTimeout<T>(ms: number, promise: Promise<T>): Promise<T> {
 
 export async function copyImageToClipboard(url: ImageType): Promise<void> {
     const blob = await getImageBlob(url);
+    if (!blob) return;
 
     try {
-        const data = new ClipboardItem({ [blob!.type]: blob! });
+        const data = new ClipboardItem({ [blob.type]: blob });
         await navigator.clipboard.write([data]);
         new Notice(i18next.t("interface.copied_generic"), timeouts.successNotice);
     } catch (e) {
@@ -50,7 +51,7 @@ async function getImageBlob(file: ImageType): Promise<Blob | null> {
 
 // https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
 // option?: https://www.npmjs.com/package/html-to-image
-export function loadImageBlob(imgSrc: string): Promise<Blob | null> {
+function loadImageBlob(imgSrc: string): Promise<Blob | null> {
     const loadImageBlobCore = (): Promise<Blob | null> =>
         new Promise<Blob | null>((resolve, reject) => {
             const image = new Image();

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,6 @@
 import { type App, Notice, normalizePath, TFile } from "obsidian";
 
+/** URL string or internal image. */
 type ImageType = string | TFile;
 
 export const timeouts = {
@@ -20,8 +21,8 @@ export function clearUrl(url: URL | string): string {
     return url.toString();
 }
 
-export async function copyImageToClipboard(url: ImageType): Promise<void> {
-    const blob = await getImageBlob(url);
+export async function copyImageToClipboard(image: ImageType): Promise<void> {
+    const blob = await getImageBlob(image);
     if (!blob) return;
 
     try {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -20,15 +20,6 @@ export function clearUrl(url: URL | string): string {
     return url.toString();
 }
 
-export function withTimeout<T>(ms: number, promise: Promise<T>): Promise<T> {
-    const timeout = new Promise<never>((_, reject) =>
-        setTimeout(() => {
-            reject(new Error(`timed out after ${ms} ms`));
-        }, ms),
-    );
-    return Promise.race([promise, timeout]);
-}
-
 export async function copyImageToClipboard(url: ImageType): Promise<void> {
     const blob = await getImageBlob(url);
     if (!blob) return;
@@ -85,6 +76,15 @@ function loadImageBlob(imgSrc: string): Promise<Blob | null> {
             image.src = imgSrc;
         });
     return withTimeout(timeouts.loadImageBlob, loadImageBlobCore());
+}
+
+export function withTimeout<T>(ms: number, promise: Promise<T>): Promise<T> {
+    const timeout = new Promise<never>((_, reject) =>
+        setTimeout(() => {
+            reject(new Error(`timed out after ${ms} ms`));
+        }, ms),
+    );
+    return Promise.race([promise, timeout]);
 }
 
 export function onElementToOff<K extends keyof DocumentEventMap>(

--- a/src/main.ts
+++ b/src/main.ts
@@ -143,7 +143,7 @@ export default class CopyUrlInPreview extends Plugin {
 
         menu.addItem((item) =>
             setItem(item, "copy-to-clipboard").onClick(() => {
-                void copyImageToClipboard(imageElement.src);
+                void copyImageToClipboard(internalFile ?? imageElement.src);
             }),
         );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,8 +49,8 @@ export default class CopyUrlInPreview extends Plugin {
                         }),
                     );
                     menu.addItem((item) =>
-                        setItem(item, "copy-to-clipboard").onClick(async () => {
-                            void copyImageToClipboard(await this.app.vault.readBinary(file));
+                        setItem(item, "copy-to-clipboard").onClick(() => {
+                            void copyImageToClipboard(file);
                         }),
                     );
                 }


### PR DESCRIPTION
I was trying stuff on another branches and I think this would fit great on `main`.

The commits are self explanatory, just moving functions around.

I added `getImageBlob()` and `ImageType` as the general way to get the `Blob` of both kind of images, `internal (TFile)` and `external (URL)`.