### PR TITLE
tsconfig: replace 'baseUrl' with 'paths'

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": "src",
+    "paths": { "*": ["./src/*"] },
     "inlineSourceMap": true,
     "inlineSources": true,
     "module": "ESNext",


### PR DESCRIPTION
`baseUrl` will be [deprecated](https://github.com/microsoft/TypeScript/issues/62207) in Typescript 6.0.

Replaced with `paths` instead.